### PR TITLE
fix: handle chart directory errors individually

### DIFF
--- a/src/charts.js
+++ b/src/charts.js
@@ -29,6 +29,9 @@ function findCharts(chartBaseDir) {
       result[chart.identifier] = chart
       return result
     }, {}))
+    .catch(err => {
+      console.error(`Error reading charts directory ${chartBaseDir}:${err.message}`)
+    })
 }
 
 function openMbtilesFile(file, filename) {


### PR DESCRIPTION
This fixes a problem where a single erroring chart directory
would cause the whole Promise series to abort and all other
chart directories coming after the bad one would be ignored.

Fixes #4.