### PR TITLE
Add ServerType and chartLayers configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Signal K Node server plugin to provide chart metadata, such as name, description
 
 <img src="https://user-images.githubusercontent.com/1435910/45048136-c65d2e80-b083-11e8-99db-01e8cece9f89.png" alt="Online chart providers configuration" width="450"/>
 
+_WMS example:_
+![image](https://user-images.githubusercontent.com/38519157/102832518-90077100-443e-11eb-9a1d-d0806bb2b10b.png)
+
 5. Activate plugin
 
 6. Use one of the client apps supporting Signal K charts, for example:

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -143,14 +143,15 @@ module.exports = function(app) {
               url: {
                 type: 'string',
                 title: 'URL',
-                description: 'Tileset URL containing {z}, {x} and {y} parameters, for example "http://example.org/{z}/{x}/{y}.png"'
+                description: 'Map URL (for tilelayer include {z}, {x} and {y} parameters, e.g. "http://example.org/{z}/{x}/{y}.png")'
               },
               layers: {
                 type: 'array',
                 title: 'Layers',
+                description: '(WMS only) ',
                 items: {
                     title: 'Layer Name',
-                    description: '(WMS maps only) Name of layer to fetch and display',
+                    description: 'Name of layer to display',
                     type: 'string'
                 }
               }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -128,6 +128,12 @@ module.exports = function(app) {
                 minimum: MIN_ZOOM,
                 default: 15,
               },
+              serverType: {
+                type: 'string',
+                title: 'Server Type',
+                default: 'tilelayer',
+                enum: ['tilelayer', 'WMS']
+              },
               format: {
                 type: 'string',
                 title: 'Format',
@@ -138,6 +144,15 @@ module.exports = function(app) {
                 type: 'string',
                 title: 'URL',
                 description: 'Tileset URL containing {z}, {x} and {y} parameters, for example "http://example.org/{z}/{x}/{y}.png"'
+              },
+              layers: {
+                type: 'array',
+                title: 'Layers',
+                items: {
+                    title: 'Layer Name',
+                    description: '(WMS maps only) Name of layer to fetch and display',
+                    type: 'string'
+                }
               }
             }
           }
@@ -170,10 +185,11 @@ function convertOnlineProviderConfig(provider) {
     minzoom: Math.min(Math.max(1, provider.minzoom), 19),
     maxzoom: Math.min(Math.max(1, provider.maxzoom), 19),
     format: provider.format,
-    type: 'tilelayer',
     scale: 'N/A',
     identifier: id,
-    tilemapUrl: provider.url
+    tilemapUrl: provider.url,
+    type: (provider.serverType) ? provider.serverType : 'tilelayer',
+    chartLayers: (provider.layers) ? provider.layers : null
   }
 }
 


### PR DESCRIPTION
Add configuration to set:
1. `type`: select between the previous `tilelayer` value and `WMS` to indicate the type of map source
2. `chartLayers`: add config section to populate the `chartLayers` attribute as per the specification.

