### PR TITLE
chore: update @mapbox/mbtiles

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "email": "mikko.vesikkala@iki.fi"
   },
   "dependencies": {
-    "@mapbox/mbtiles": "0.10.0",
+    "@mapbox/mbtiles": "^0.12.1",
     "baconjs": "1.0.1",
     "bluebird": "3.5.1",
     "debug": "3.1.0",

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -25,7 +25,7 @@ module.exports = function(app) {
       result[provider.identifier] = provider
       return result
     }, {})
-    debug(`Start charts plugin. Chart paths: ${chartPaths.join(', ')}, online charts: ${onlineProviders.length}`)
+    console.log(`Start charts plugin. Chart paths: ${chartPaths.join(', ')}, online charts: ${onlineProviders.length}`)
 
     const loadProviders = Promise.mapSeries(chartPaths, chartPath => Charts.findCharts(chartPath))
       .then(list => _.reduce(list, (result, charts) => _.merge({}, result, charts), {}))


### PR DESCRIPTION
^0.12.1 uses sqlite3@^5.0.0 that has prebuilt binaries, so installs should be much much quicker and less error prone.

Fixes #23 .