### PR TITLE
Add File watcher support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ coverage
 # Stryker mutation testing
 reports
 .stryker-tmp
+
+# Temp dirs used by watcher tests
+test/.tmp

--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ You can either:
 
 <img src="https://user-images.githubusercontent.com/1435910/39382493-57c1e4dc-4a6e-11e8-93e1-cedb4c7662f4.png" alt="Chart paths configuration" width="450"/>
 
->**Note:** After chart files have been added to folders they will be processed after the plugin has been restarted! _(disable / enable the plugin)_ 
+The plugin watches each configured chart path and picks up new, renamed, or deleted chart files automatically, including files in nested subdirectories (e.g. `charts/<region>/<chart>.mbtiles`). Changes are applied after a short debounce (5 seconds by default) so bursts of events from file copies and atomic saves are collapsed into a single reload.
+
+>**Note:** File-system watching relies on native OS events. On some network mounts (SMB/NFS) events may be missed; if a chart doesn't appear after the debounce window, disable and re-enable the plugin.
 
 
 ### Online chart providers

--- a/src/charts.ts
+++ b/src/charts.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 import * as xml2js from 'xml2js'
-import { promises as fs } from 'fs'
+import { Dirent, promises as fs } from 'fs'
 import * as _ from 'lodash'
 import { ChartProvider } from './types'
 import { promisify } from 'util'
@@ -25,52 +25,66 @@ async function loadMBTiles() {
   }
 }
 
-export function findCharts(chartBaseDir: string) {
-  return loadMBTiles()
-    .then(() => fs.readdir(chartBaseDir, { withFileTypes: true }))
-    .then(async (files) => {
-      const results = []
-      for (const file of files) {
-        const isMbtilesFile = file.name.match(/\.mbtiles$/i)
-        const filePath = path.resolve(chartBaseDir, file.name)
-        const isDirectory = file.isDirectory()
-        if (isMbtilesFile) {
-          if (mbtilesLoadError) {
-            console.warn(
-              `Skipping mbtiles file ${file.name}: MBTiles module not available`
-            )
-            results.push(null)
-          } else {
-            results.push(await openMbtilesFile(filePath, file.name))
-          }
-        } else if (isDirectory) {
-          results.push(await directoryToMapInfo(filePath, file.name))
-        } else {
-          results.push(null)
-        }
+// Recursively scans chartBaseDir and any non-chart subdirectories. A directory
+// is treated as a chart if it has tilemapresource.xml or metadata.json; anything
+// else is descended into so layouts like charts/<region>/<chart> work without
+// having to list every subdir in the plugin config. Symlinks are skipped and
+// the depth is bounded so a misplaced config entry can't send the scan into
+// node_modules or a symlink loop.
+const MAX_SCAN_DEPTH = 8
+
+export async function findCharts(
+  chartBaseDir: string
+): Promise<{ [identifier: string]: ChartProvider }> {
+  await loadMBTiles()
+  const charts: ChartProvider[] = []
+  await scanDir(chartBaseDir, charts, 0)
+  return _.reduce(
+    charts,
+    (result, chart) => {
+      result[chart.identifier] = chart
+      return result
+    },
+    {} as { [identifier: string]: ChartProvider }
+  )
+}
+
+async function scanDir(
+  dir: string,
+  out: ChartProvider[],
+  depth: number
+): Promise<void> {
+  if (depth > MAX_SCAN_DEPTH) return
+  let entries: Dirent[]
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true })
+  } catch (err) {
+    console.error(
+      `Error reading charts directory ${dir}:${(err as Error).message}`
+    )
+    return
+  }
+  for (const entry of entries) {
+    if (entry.isSymbolicLink()) continue
+    const entryPath = path.resolve(dir, entry.name)
+    if (entry.name.match(/\.mbtiles$/i)) {
+      if (mbtilesLoadError) {
+        console.warn(
+          `Skipping mbtiles file ${entry.name}: MBTiles module not available`
+        )
+        continue
       }
-      return results
-    })
-    .then(
-      (result: (ChartProvider | null | undefined)[]) =>
-        _.filter(result, _.identity) as ChartProvider[]
-    )
-    .then((charts: ChartProvider[]) =>
-      _.reduce(
-        charts,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (result: any, chart: ChartProvider) => {
-          result[chart.identifier] = chart
-          return result
-        },
-        {}
-      )
-    )
-    .catch((err: Error) => {
-      console.error(
-        `Error reading charts directory ${chartBaseDir}:${err.message}`
-      )
-    })
+      const chart = await openMbtilesFile(entryPath, entry.name)
+      if (chart) out.push(chart as ChartProvider)
+    } else if (entry.isDirectory()) {
+      const chart = await directoryToMapInfo(entryPath, entry.name)
+      if (chart) {
+        out.push(chart as ChartProvider)
+      } else {
+        await scanDir(entryPath, out, depth + 1)
+      }
+    }
+  }
 }
 
 function openMbtilesFile(file: string, filename: string) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import path from 'path'
-import fs from 'fs'
+import fs, { FSWatcher } from 'fs'
 import * as _ from 'lodash'
 import { findCharts } from './charts'
 import { apiRoutePrefix } from './constants'
@@ -34,6 +34,11 @@ interface ChartProviderApp
 const MIN_ZOOM = 1
 const MAX_ZOOM = 24
 const chartTilesPath = '/signalk/chart-tiles'
+// Debounce window used to collapse FSWatcher bursts during rename / atomic-save
+// sequences into one reload. Overridable via env var so tests don't have to
+// wait the full 5s on every watcher assertion.
+const RELOAD_DEBOUNCE_MS =
+  Number(process.env.SK_CHARTS_RELOAD_DEBOUNCE_MS) || 5000
 
 module.exports = (app: ChartProviderApp): Plugin => {
   let chartProviders: { [key: string]: ChartProvider } = {}
@@ -53,6 +58,14 @@ module.exports = (app: ChartProviderApp): Plugin => {
   ensureDirectoryExists(defaultChartsPath)
 
   let cachePath = defaultChartsPath
+
+  // Chart-folder watcher state, plugin-scoped so stop()/start() cycles reset cleanly.
+  // activeChartPaths / activeOnlineProviders hold the last-known config so a
+  // watcher-triggered reload can reuse it without re-running doStartup.
+  const watchers: FSWatcher[] = []
+  let reloadTimer: NodeJS.Timeout | undefined
+  let activeChartPaths: string[] = []
+  let activeOnlineProviders: { [key: string]: object } = {}
 
   // Check Node version for schema
   const nodeVersion = process.versions.node
@@ -200,6 +213,14 @@ module.exports = (app: ChartProviderApp): Plugin => {
       return doStartup(settings) // return required for tests
     },
     stop: () => {
+      stopWatchers()
+      // Close open SQLite connections so the user can move or delete chart
+      // files while the plugin is stopped (Windows blocks deletion on open
+      // handles). Restart re-opens fresh via findCharts.
+      for (const p of Object.values(chartProviders)) {
+        if (p?._mbtilesHandle) closeMbtilesHandle(p._mbtilesHandle)
+      }
+      chartProviders = {}
       app.setPluginStatus('stopped')
     }
   }
@@ -223,13 +244,13 @@ module.exports = (app: ChartProviderApp): Plugin => {
     }`
     app.debug(`**urlBase** ${urlBase}`)
 
-    const chartPaths = _.isEmpty(props.chartPaths)
+    activeChartPaths = _.isEmpty(props.chartPaths)
       ? [defaultChartsPath]
       : resolveUniqueChartPaths(props.chartPaths, configBasePath)
     cachePath = props.cachePath || defaultChartsPath
     ensureDirectoryExists(cachePath)
 
-    const onlineProviders = _.reduce(
+    activeOnlineProviders = _.reduce(
       props.onlineChartProviders,
       (result: { [key: string]: object }, data) => {
         const provider = convertOnlineProviderConfig(data)
@@ -239,9 +260,9 @@ module.exports = (app: ChartProviderApp): Plugin => {
       {}
     )
     app.debug(
-      `Start charts plugin. Chart paths: ${chartPaths.join(
+      `Start charts plugin. Chart paths: ${activeChartPaths.join(
         ', '
-      )}, online charts: ${Object.keys(onlineProviders).length}`
+      )}, online charts: ${Object.keys(activeOnlineProviders).length}`
     )
 
     // Do not register routes if plugin has been started once already
@@ -256,30 +277,154 @@ module.exports = (app: ChartProviderApp): Plugin => {
 
     app.setPluginStatus('Started')
 
-    const loadProviders = (async () => {
-      const list = []
-      for (const chartPath of chartPaths) {
+    startWatchers()
+    return loadChartProviders()
+  }
+
+  const loadChartProviders = async (): Promise<void> => {
+    let newCharts: { [key: string]: ChartProvider } = {}
+    try {
+      const list: ({ [key: string]: ChartProvider } | undefined)[] = []
+      for (const chartPath of activeChartPaths) {
         list.push(await findCharts(chartPath))
       }
-      return list
-    })().then((list: ChartProvider[]) =>
-      _.reduce(list, (result, charts) => _.merge({}, result, charts), {})
-    )
+      newCharts = _.reduce(
+        list,
+        (result, c) => _.merge({}, result, c),
+        {} as { [key: string]: ChartProvider }
+      )
+      app.debug(
+        `Chart plugin: Found ${
+          _.keys(newCharts).length
+        } charts from ${activeChartPaths.join(', ')}.`
+      )
+    } catch (e) {
+      // Keep the last-good chartProviders instead of wiping everything - a
+      // transient read error (file locked during copy, EBUSY, etc.) shouldn't
+      // blank the service out until the next filesystem event.
+      console.error(`Error loading chart providers`, (e as Error).message)
+      app.setPluginError(`Error loading chart providers`)
+      return
+    }
 
-    return loadProviders
-      .then((charts: { [key: string]: ChartProvider }) => {
-        app.debug(
-          `Chart plugin: Found ${
-            _.keys(charts).length
-          } charts from ${chartPaths.join(', ')}.`
+    reconcileMbtilesHandles(chartProviders, newCharts)
+    chartProviders = _.merge({}, newCharts, activeOnlineProviders)
+    app.setPluginStatus(
+      `Started - ${_.keys(chartProviders).length} chart(s) loaded`
+    )
+  }
+
+  // When a file is still present across a reload, reuse the existing SQLite
+  // handle instead of the freshly-opened one from findCharts. Closes handles
+  // for files that have gone away. Without this, every reload leaks a SQLite
+  // connection per MBTiles file.
+  const reconcileMbtilesHandles = (
+    oldSet: { [key: string]: ChartProvider },
+    newSet: { [key: string]: ChartProvider }
+  ) => {
+    const newPaths = new Set<string>()
+    for (const p of Object.values(newSet)) {
+      if (p?._filePath) newPaths.add(p._filePath)
+    }
+    for (const [id, n] of Object.entries(newSet)) {
+      const old = oldSet[id]
+      if (
+        n?._mbtilesHandle &&
+        old?._mbtilesHandle &&
+        old._filePath === n._filePath
+      ) {
+        // Drop the newly-opened handle; reuse the existing one so in-flight
+        // requests that captured a reference keep working.
+        closeMbtilesHandle(n._mbtilesHandle)
+        n._mbtilesHandle = old._mbtilesHandle
+      }
+    }
+    for (const old of Object.values(oldSet)) {
+      if (
+        old?._mbtilesHandle &&
+        old._filePath &&
+        !newPaths.has(old._filePath)
+      ) {
+        closeMbtilesHandle(old._mbtilesHandle)
+      }
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const closeMbtilesHandle = (handle: any) => {
+    if (typeof handle?.close !== 'function') return
+    try {
+      handle.close((err: Error | null) => {
+        if (err) app.debug(`MBTiles close error: ${err.message}`)
+      })
+    } catch (err) {
+      app.debug(`MBTiles close threw: ${(err as Error).message}`)
+    }
+  }
+
+  // Chart folders are watched so new/renamed/deleted files become visible
+  // without a plugin restart. FSWatcher bursts events during rename and
+  // atomic-save sequences; the debounce collapses a burst into one reload.
+  const scheduleReload = () => {
+    if (reloadTimer) clearTimeout(reloadTimer)
+    reloadTimer = setTimeout(() => {
+      reloadTimer = undefined
+      app.debug('Reloading charts after filesystem change')
+      loadChartProviders()
+    }, RELOAD_DEBOUNCE_MS)
+  }
+
+  const startWatchers = () => {
+    stopWatchers()
+    for (const p of activeChartPaths) {
+      watchers.push(...createWatchers(p))
+    }
+  }
+
+  // recursive:true is the common path on macOS / Windows / Linux (Node 22+).
+  // If the platform or filesystem doesn't support it (some network mounts,
+  // older Linux), fall back to a non-recursive watch so at least top-level
+  // changes are picked up.
+  const createWatchers = (p: string): FSWatcher[] => {
+    const handlers: FSWatcher[] = []
+    try {
+      const watcher = fs.watch(p, { encoding: 'utf8', recursive: true }, () =>
+        scheduleReload()
+      )
+      watcher.on('error', (err) =>
+        app.debug(`Watcher error on ${p}: ${err.message}`)
+      )
+      handlers.push(watcher)
+      app.debug(`Watching chart folder recursively: ${p}`)
+    } catch (err) {
+      app.debug(
+        `Recursive watch unavailable for ${p} (${
+          (err as Error).message
+        }); falling back to top-level watch`
+      )
+      try {
+        const watcher = fs.watch(p, { encoding: 'utf8' }, () =>
+          scheduleReload()
         )
-        chartProviders = _.merge({}, charts, onlineProviders)
-      })
-      .catch((e: Error) => {
-        console.error(`Error loading chart providers`, e.message)
-        chartProviders = {}
-        app.setPluginError(`Error loading chart providers`)
-      })
+        watcher.on('error', (e) =>
+          app.debug(`Watcher error on ${p}: ${e.message}`)
+        )
+        handlers.push(watcher)
+      } catch (e) {
+        app.debug(`Unable to watch ${p}: ${(e as Error).message}`)
+      }
+    }
+    return handlers
+  }
+
+  const stopWatchers = () => {
+    if (reloadTimer) {
+      clearTimeout(reloadTimer)
+      reloadTimer = undefined
+    }
+    while (watchers.length) {
+      watchers.pop()?.close()
+    }
   }
 
   const registerRoutes = () => {

--- a/test/plugin-test.ts
+++ b/test/plugin-test.ts
@@ -12,6 +12,12 @@ import express from 'express'
 import bodyParser from 'body-parser'
 import chai from 'chai'
 import chaiHttp from 'chai-http'
+
+// Short debounce so watcher-based tests don't wait 5s per assertion. Must be
+// set before requiring the plugin so the module-level RELOAD_DEBOUNCE_MS picks
+// it up.
+process.env.SK_CHARTS_RELOAD_DEBOUNCE_MS = '150'
+
 import Plugin = require('../plugin/index')
 import expectedCharts from './expected-charts.json'
 
@@ -19,6 +25,16 @@ chai.use(chaiHttp)
 const expect = chai.expect
 
 type PluginInstance = ReturnType<typeof Plugin>
+
+// Slightly larger than the debounce, plus slack for the filesystem event to
+// propagate and the reload to complete.
+const RELOAD_WAIT_MS = 600
+const wait = (ms: number) => new Promise<void>((r) => setTimeout(r, ms))
+
+// Keep the watcher-test temp dir on the same drive as the repo. @signalk/mbtiles
+// mangles Windows paths via url.parse (drive letter becomes the protocol), so
+// a cross-drive path like C:\Users\...\Temp from a D:\ checkout fails to open.
+const TMP_BASE = path.resolve(__dirname, '.tmp')
 
 describe('GET /resources/charts', () => {
   let plugin: PluginInstance
@@ -30,7 +46,10 @@ describe('GET /resources/charts', () => {
       testServer = server
     })
   )
-  afterEach(done => testServer.close(() => done()))
+  afterEach(done => {
+    if (plugin && plugin.stop) plugin.stop()
+    testServer.close(() => done())
+  })
 
   it('returns all charts for default path', () => {
     return plugin.start({})
@@ -129,7 +148,10 @@ describe('GET /signalk/chart-tiles/:identifier/:z/:x/:y', () => {
       testServer = server
     })
   )
-  afterEach(done => testServer.close(() => done()))
+  afterEach(done => {
+    if (plugin && plugin.stop) plugin.stop()
+    testServer.close(() => done())
+  })
 
   it('returns correct tile from MBTiles file', () => {
     return plugin.start({})
@@ -173,6 +195,113 @@ describe('GET /signalk/chart-tiles/:identifier/:z/:x/:y', () => {
       .then(response => {
         expect(response.status).to.equal(404)
       })
+  })
+})
+
+describe('chart folder watcher', function () {
+  this.timeout(10000)
+  let plugin: PluginInstance
+  let testServer: http.Server
+  let tmpDir: string
+  const fixtureMbtiles = path.resolve(__dirname, 'charts/test.mbtiles')
+
+  beforeEach(() => {
+    fs.mkdirSync(TMP_BASE, { recursive: true })
+    return createDefaultApp().then(({ app, server }) => {
+      plugin = Plugin(app)
+      testServer = server
+      tmpDir = fs.mkdtempSync(path.join(TMP_BASE, 'watch-'))
+    })
+  })
+  afterEach(done => {
+    if (plugin && plugin.stop) plugin.stop()
+    testServer.close(() => {
+      // Give Windows a moment to release any file handles we just closed.
+      setTimeout(() => {
+        try {
+          fs.rmSync(tmpDir, {
+            recursive: true,
+            force: true,
+            maxRetries: 5,
+            retryDelay: 50
+          })
+        } catch {
+          // best-effort cleanup
+        }
+        done()
+      }, 50)
+    })
+  })
+
+  it('picks up a new chart file added after startup', async () => {
+    await plugin.start({ chartPaths: [tmpDir] })
+    let response = await get(testServer, '/signalk/v1/api/resources/charts')
+    expect(Object.keys(response.body).length).to.equal(0)
+
+    fs.copyFileSync(fixtureMbtiles, path.join(tmpDir, 'added.mbtiles'))
+    await wait(RELOAD_WAIT_MS)
+
+    response = await get(testServer, '/signalk/v1/api/resources/charts')
+    expect(Object.keys(response.body)).to.include('added')
+  })
+
+  it('drops a chart that has been deleted', async () => {
+    // Use a directory-based chart (TMS tiles) rather than an .mbtiles file.
+    // Deleting an open SQLite file is blocked on Windows; directories aren't,
+    // so this exercises the watcher's "removal" path without being tangled up
+    // in node:sqlite file-locking behavior.
+    const tmsSrc = path.resolve(__dirname, 'charts/tms-tiles')
+    const tmsDst = path.join(tmpDir, 'deleteme')
+    fs.cpSync(tmsSrc, tmsDst, { recursive: true })
+
+    await plugin.start({ chartPaths: [tmpDir] })
+    let response = await get(testServer, '/signalk/v1/api/resources/charts')
+    expect(Object.keys(response.body)).to.include('deleteme')
+
+    fs.rmSync(tmsDst, { recursive: true, force: true })
+    await wait(RELOAD_WAIT_MS)
+
+    response = await get(testServer, '/signalk/v1/api/resources/charts')
+    expect(Object.keys(response.body)).to.not.include('deleteme')
+  })
+
+  it('discovers charts in nested subdirectories', async () => {
+    const region = path.join(tmpDir, 'region-a')
+    fs.mkdirSync(region)
+    fs.copyFileSync(fixtureMbtiles, path.join(region, 'nested.mbtiles'))
+
+    await plugin.start({ chartPaths: [tmpDir] })
+    const response = await get(testServer, '/signalk/v1/api/resources/charts')
+    expect(Object.keys(response.body)).to.include('nested')
+  })
+
+  it('picks up a chart added to a nested subdirectory after startup', async () => {
+    const region = path.join(tmpDir, 'region-b')
+    fs.mkdirSync(region)
+    await plugin.start({ chartPaths: [tmpDir] })
+
+    fs.copyFileSync(fixtureMbtiles, path.join(region, 'late.mbtiles'))
+    await wait(RELOAD_WAIT_MS)
+
+    const response = await get(testServer, '/signalk/v1/api/resources/charts')
+    expect(Object.keys(response.body)).to.include('late')
+  })
+
+  it('ignores invalid files without dropping good charts', async () => {
+    fs.copyFileSync(fixtureMbtiles, path.join(tmpDir, 'stable.mbtiles'))
+    await plugin.start({ chartPaths: [tmpDir] })
+
+    let response = await get(testServer, '/signalk/v1/api/resources/charts')
+    expect(Object.keys(response.body)).to.include('stable')
+
+    // An .mbtiles file that isn't a valid SQLite database. openMbtilesFile
+    // rejects it, but that shouldn't take out the 'stable' chart already loaded.
+    fs.writeFileSync(path.join(tmpDir, 'broken.mbtiles'), 'not a sqlite db')
+    await wait(RELOAD_WAIT_MS)
+
+    response = await get(testServer, '/signalk/v1/api/resources/charts')
+    expect(Object.keys(response.body)).to.include('stable')
+    expect(Object.keys(response.body)).to.not.include('broken')
   })
 })
 


### PR DESCRIPTION
This PR adds a file watcher to charts folders to detect new files placed in the folder. This makes the new charts available to subsequent requests without having to restart the plugin (#28). 





