### PR TITLE
fix: v2 api provider startups

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -187,6 +187,13 @@ module.exports = (app: ChartProviderApp): Plugin => {
     // Do not register routes if plugin has been started once already
     pluginStarted === false && registerRoutes()
     pluginStarted = true
+
+    // v2 routes - register as Resource Provider, this needs to be always on startup
+    if (serverMajorVersion === 2) {
+      app.debug('** Registering v2 API paths **')
+      registerAsProvider()
+    }
+
     const urlBase = `${app.config.ssl ? 'https' : 'http'}://localhost:${
       'getExternalPort' in app.config ? app.config.getExternalPort() : 3000
     }`
@@ -273,12 +280,6 @@ module.exports = (app: ChartProviderApp): Plugin => {
       )
       res.json(sanitized)
     })
-
-    // v2 routes
-    if (serverMajorVersion === 2) {
-      app.debug('** Registering v2 API paths **')
-      registerAsProvider()
-    }
   }
 
   // Resources API provider registration


### PR DESCRIPTION
Saving the plugin configuration causes a plugin
restart and the server plugin manager will
automatically unregister providers. With v2
provider registrating added at the end of
registerRoutes it would not get re-registered
on plugin restart, becase there's explicit
logic preventing calling registerRoutes on
subsequent starts.

The net result of this was that saving
the plugin config would cause the charts api
to return {}.