### PR TITLE
Use pure js mbtiles

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
         node-version: [22.x, 24.x]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v3
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.0.0]
+        node-version: [22.x, 24.x]
 
     steps:
     - uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "email": "mikko.vesikkala@iki.fi"
   },
   "dependencies": {
-    "@mapbox/mbtiles": "^0.12.1",
+    "@signalk/mbtiles" : "0.1.1",
     "@signalk/server-api": "^2.0.0",
     "@turf/bbox": "^7.2.0",
     "@turf/boolean-intersects": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@turf/bbox": "^7.2.0",
     "@turf/boolean-intersects": "^7.2.0",
     "@turf/helpers": "^7.2.0",
-    "bluebird": "3.5.1",
     "check-disk-space": "^3.4.0",
     "geojson-antimeridian-cut": "^0.1.0",
     "lodash": "^4.17.11",

--- a/src/@types/bluebird.d.ts
+++ b/src/@types/bluebird.d.ts
@@ -1,1 +1,0 @@
-declare module 'bluebird'

--- a/src/@types/mapbox_mbtiles.d.ts
+++ b/src/@types/mapbox_mbtiles.d.ts
@@ -1,1 +1,0 @@
-declare module '@mapbox/mbtiles'

--- a/src/@types/signalk_mbtiles.d.ts
+++ b/src/@types/signalk_mbtiles.d.ts
@@ -1,0 +1,1 @@
+declare module '@signalk/mbtiles'

--- a/src/charts.ts
+++ b/src/charts.ts
@@ -1,6 +1,6 @@
 import * as bluebird from 'bluebird'
 import path from 'path'
-import MBTiles from '@mapbox/mbtiles'
+import MBTiles from '@signalk/mbtiles'
 import * as xml2js from 'xml2js'
 import { Dirent, promises as fs } from 'fs'
 import * as _ from 'lodash'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import * as bluebird from 'bluebird'
 import path from 'path'
 import fs from 'fs'
 import * as _ from 'lodash'
@@ -250,8 +249,13 @@ module.exports = (app: ChartProviderApp): Plugin => {
 
     app.setPluginStatus('Started')
 
-    const loadProviders = bluebird
-      .mapSeries(chartPaths, (chartPath: string) => findCharts(chartPath))
+    const loadProviders = (async () => {
+      const list = []
+      for (const chartPath of chartPaths) {
+        list.push(await findCharts(chartPath))
+      }
+      return list
+    })()
       .then((list: ChartProvider[]) =>
         _.reduce(list, (result, charts) => _.merge({}, result, charts), {})
       )

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,12 @@ module.exports = (app: ChartProviderApp): Plugin => {
     title: 'Signal K Charts',
     type: 'object',
     properties: {
+      versionWarning: {
+        type: 'string',
+        title: 'REQUIRES NODE VERSION >=22',
+        description: 'Starting with version 4 this plugin will not work with Node versions older than 22. You can install an older plugin version from the App store.',
+        default: ''
+      },
       chartPaths: {
         type: 'array',
         title: 'Chart paths',
@@ -193,6 +199,16 @@ module.exports = (app: ChartProviderApp): Plugin => {
   }
 
   const doStartup = (config: Config) => {
+    // Check Node version
+    const nodeVersion = process.versions.node
+    const majorVersion = parseInt(nodeVersion.split('.')[0])
+    if (majorVersion < 22) {
+      const errorMsg = `Node version ${nodeVersion} is not supported. This plugin requires Node version 22 or higher. Please upgrade Node or install an older plugin version.`
+      app.setPluginError(errorMsg)
+      app.debug(errorMsg)
+      return Promise.reject(new Error(errorMsg))
+    }
+
     app.debug(`** loaded config: ${config}`)
     props = { ...config }
 

--- a/test/plugin-test.js
+++ b/test/plugin-test.js
@@ -5,7 +5,6 @@ const path = require('path')
 const http = require('http')
 const chai = require('chai')
 const chaiHttp = require('chai-http')
-const Promise = require('bluebird')
 const express = require('express')
 const expect = chai.expect
 const Plugin = require('../plugin/index')


### PR DESCRIPTION
Replace @signalk/node-mbtiles with the experimental, Claude-coded version of mbtiles support that uses
Node's upcoming (but still experimental) node:sqlite module for sqlite file access.

Sqlite3 that is a dependency of @mapbox/mbtiles, has caused problems in the past (installation requires often compiling the native bindings that is either slow on a Pi or error prone) and Node 24 with node:sqlite support madeActive  LTS yesterday(!) I think we could switch this plugin over. https://github.com/SignalK/signalk-server/pull/2126 will allow people with older Nodes to install older versions.