### PR TITLE
Add {bbox} and {bbox_3857} URL substitution for WMS proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,28 @@ For WMS & WMTS sources you can specify the layers you wish to display.
 
 A proxy for online charts can be created using the "Proxy through SignalK server" option. If enabled tiles will be fetched from the remote server and cached by the SignalK server making it possible to store the tiles for offline usage. Additional http headers can be passed to the remote server by adding colon separated headers, e.g. User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64). User-Agent is the header name and Mozilla... will be the value.
 
+#### URL placeholders
+
+The following placeholders are substituted in the chart URL when the proxy fetches each tile:
+
+| Placeholder | Replaced with |
+|---|---|
+| `{z}` | Tile zoom level |
+| `{x}` | Tile column |
+| `{y}` | Tile row (XYZ / Google / OSM scheme, origin at top-left) |
+| `{-y}` | Tile row flipped to TMS scheme (origin at bottom-left) |
+| `{z-2}` | Zoom minus 2, for NOAA WMTS sources served as a tilemap |
+| `{bbox}` | Tile bounds in EPSG:4326, as `minLon,minLat,maxLon,maxLat` (WMS 1.1.1 axis order) |
+| `{bbox_3857}` | Tile bounds in EPSG:3857 / Web Mercator meters, as `minX,minY,maxX,maxY` |
+
+`{bbox}` and `{bbox_3857}` make it possible to proxy and cache WMS sources that do not offer an XYZ endpoint. Prefer `{bbox_3857}` with WMS 1.3.0 endpoints, because WMS 1.3.0 requires `lat,lon` axis order for geographic CRSes such as EPSG:4326 and `{bbox}` always emits `lon,lat`.
+
+Example: NOAA Chart Display Service (S-57 ENC) as a cacheable tile source — set server type `tilelayer`, format `png`, proxy enabled, and use:
+
+```
+https://gis.charttools.noaa.gov/arcgis/rest/services/MCS/NOAAChartDisplay/MapServer/exts/MaritimeChartService/WMSServer?service=WMS&version=1.3.0&request=GetMap&layers=0,1,2,3,4,5,6,7,8,9,10,11,12&styles=&crs=EPSG:3857&bbox={bbox_3857}&width=256&height=256&format=image/png&transparent=true
+```
+
 ### Supported chart formats
 
 - [MBTiles](https://github.com/mapbox/mbtiles-spec) files

--- a/src/chartDownloader.ts
+++ b/src/chartDownloader.ts
@@ -16,6 +16,7 @@ import { polygon } from '@turf/helpers'
 import checkDiskSpace from 'check-disk-space'
 import { ResourcesApi } from '@signalk/server-api'
 import { ChartProvider } from './types'
+import { lonLatToMercator, tileToBBox } from './projection'
 
 export interface Tile {
   x: number
@@ -309,13 +310,23 @@ export class ChartDownloader {
       .replace('{y}', tile.y.toString())
       .replace('{-y}', (Math.pow(2, tile.z) - 1 - tile.y).toString())
 
-    // Support {bbox} (EPSG:4326) and {bbox_3857} (EPSG:3857) for WMS-style sources
+    // Support {bbox} (EPSG:4326) and {bbox_3857} (EPSG:3857) for WMS-style sources.
+    // {bbox} emits minLon,minLat,maxLon,maxLat — this is WMS 1.1.1 order, and also
+    // matches WMS 1.3.0 for projected CRSes. For WMS 1.3.0 with a geographic CRS
+    // (e.g. EPSG:4326) the spec requires lat,lon axis order; prefer {bbox_3857} in
+    // that case, or use a WMS 1.1.1 endpoint.
     if (url.includes('{bbox}') || url.includes('{bbox_3857}')) {
-      const [minLon, minLat, maxLon, maxLat] = ChartDownloader.tileToBBox(tile.x, tile.y, tile.z)
-      url = url.replace('{bbox}', `${minLon},${minLat},${maxLon},${maxLat}`)
+      const [minLon, minLat, maxLon, maxLat] = tileToBBox(
+        tile.x,
+        tile.y,
+        tile.z
+      )
+      if (url.includes('{bbox}')) {
+        url = url.replace('{bbox}', `${minLon},${minLat},${maxLon},${maxLat}`)
+      }
       if (url.includes('{bbox_3857}')) {
-        const [mx1, my1] = ChartDownloader.lonLatToMercator(minLon, minLat)
-        const [mx2, my2] = ChartDownloader.lonLatToMercator(maxLon, maxLat)
+        const [mx1, my1] = lonLatToMercator(minLon, minLat)
+        const [mx2, my2] = lonLatToMercator(maxLon, maxLat)
         url = url.replace('{bbox_3857}', `${mx1},${my1},${mx2},${my2}`)
       }
     }
@@ -432,7 +443,7 @@ export class ChartDownloader {
 
         for (let x = minX; x <= maxX; x++) {
           for (let y = minY; y <= maxY; y++) {
-            const tileBbox = ChartDownloader.tileToBBox(x, y, z)
+            const tileBbox = tileToBBox(x, y, z)
             const tilePoly = this.bboxPolygon(tileBbox)
 
             if (booleanIntersects(feature as Feature, tilePoly)) {
@@ -529,24 +540,6 @@ export class ChartDownloader {
         n
     )
     return [x, y]
-  }
-
-  static tileToBBox(x: number, y: number, z: number): BBox {
-    const n = 2 ** z
-    const lon1 = (x / n) * 360 - 180
-    const lat1 =
-      (Math.atan(Math.sinh(Math.PI * (1 - (2 * y) / n))) * 180) / Math.PI
-    const lon2 = ((x + 1) / n) * 360 - 180
-    const lat2 =
-      (Math.atan(Math.sinh(Math.PI * (1 - (2 * (y + 1)) / n))) * 180) / Math.PI
-    return [lon1, lat2, lon2, lat1]
-  }
-
-  private static lonLatToMercator(lon: number, lat: number): [number, number] {
-    const x = (lon * 20037508.34) / 180
-    const y =
-      Math.log(Math.tan(((90 + lat) * Math.PI) / 360)) / (Math.PI / 180)
-    return [x, (y * 20037508.34) / 180]
   }
 
   private bboxPolygon(boundingBox: BBox) {

--- a/src/chartDownloader.ts
+++ b/src/chartDownloader.ts
@@ -301,13 +301,24 @@ export class ChartDownloader {
       console.error(`No remote URL defined for provider ${provider.name}`)
       return null
     }
-    const url = provider.remoteUrl
+    let url = provider.remoteUrl
       .replace('{z}', tile.z.toString())
       // To be able to handle NOAA WMTS caching as a tilemap source with -2 offset
       .replace('{z-2}', (tile.z - 2).toString())
       .replace('{x}', tile.x.toString())
       .replace('{y}', tile.y.toString())
       .replace('{-y}', (Math.pow(2, tile.z) - 1 - tile.y).toString())
+
+    // Support {bbox} (EPSG:4326) and {bbox_3857} (EPSG:3857) for WMS-style sources
+    if (url.includes('{bbox}') || url.includes('{bbox_3857}')) {
+      const [minLon, minLat, maxLon, maxLat] = ChartDownloader.tileToBBox(tile.x, tile.y, tile.z)
+      url = url.replace('{bbox}', `${minLon},${minLat},${maxLon},${maxLat}`)
+      if (url.includes('{bbox_3857}')) {
+        const [mx1, my1] = ChartDownloader.lonLatToMercator(minLon, minLat)
+        const [mx2, my2] = ChartDownloader.lonLatToMercator(maxLon, maxLat)
+        url = url.replace('{bbox_3857}', `${mx1},${my1},${mx2},${my2}`)
+      }
+    }
     const controller = new AbortController()
     const id = setTimeout(() => controller.abort(), timeoutMs)
     try {
@@ -421,7 +432,7 @@ export class ChartDownloader {
 
         for (let x = minX; x <= maxX; x++) {
           for (let y = minY; y <= maxY; y++) {
-            const tileBbox = this.tileToBBox(x, y, z)
+            const tileBbox = ChartDownloader.tileToBBox(x, y, z)
             const tilePoly = this.bboxPolygon(tileBbox)
 
             if (booleanIntersects(feature as Feature, tilePoly)) {
@@ -520,7 +531,7 @@ export class ChartDownloader {
     return [x, y]
   }
 
-  private tileToBBox(x: number, y: number, z: number): BBox {
+  static tileToBBox(x: number, y: number, z: number): BBox {
     const n = 2 ** z
     const lon1 = (x / n) * 360 - 180
     const lat1 =
@@ -529,6 +540,13 @@ export class ChartDownloader {
     const lat2 =
       (Math.atan(Math.sinh(Math.PI * (1 - (2 * (y + 1)) / n))) * 180) / Math.PI
     return [lon1, lat2, lon2, lat1]
+  }
+
+  private static lonLatToMercator(lon: number, lat: number): [number, number] {
+    const x = (lon * 20037508.34) / 180
+    const y =
+      Math.log(Math.tan(((90 + lat) * Math.PI) / 360)) / (Math.PI / 180)
+    return [x, (y * 20037508.34) / 180]
   }
 
   private bboxPolygon(boundingBox: BBox) {

--- a/src/projection.ts
+++ b/src/projection.ts
@@ -1,0 +1,23 @@
+import type { BBox } from 'geojson'
+
+// EPSG:3857 half the equator circumference, in meters.
+// Used to scale lon/lat into Web Mercator x/y.
+export const WEB_MERCATOR_HALF_EXTENT_M = 20037508.34
+
+export function tileToBBox(x: number, y: number, z: number): BBox {
+  const n = 2 ** z
+  const lon1 = (x / n) * 360 - 180
+  const lat1 =
+    (Math.atan(Math.sinh(Math.PI * (1 - (2 * y) / n))) * 180) / Math.PI
+  const lon2 = ((x + 1) / n) * 360 - 180
+  const lat2 =
+    (Math.atan(Math.sinh(Math.PI * (1 - (2 * (y + 1)) / n))) * 180) / Math.PI
+  return [lon1, lat2, lon2, lat1]
+}
+
+export function lonLatToMercator(lon: number, lat: number): [number, number] {
+  const x = (lon * WEB_MERCATOR_HALF_EXTENT_M) / 180
+  const yDeg =
+    Math.log(Math.tan(((90 + lat) * Math.PI) / 360)) / (Math.PI / 180)
+  return [x, (yDeg * WEB_MERCATOR_HALF_EXTENT_M) / 180]
+}

--- a/test/projection-test.js
+++ b/test/projection-test.js
@@ -1,0 +1,96 @@
+'use strict'
+const chai = require('chai')
+const expect = chai.expect
+const {
+  WEB_MERCATOR_HALF_EXTENT_M,
+  tileToBBox,
+  lonLatToMercator
+} = require('../plugin/projection')
+
+const WEB_MERCATOR_MAX_LAT = 85.0511287798066
+
+const approx = (actual, expected, tolerance = 1e-6) => {
+  expect(
+    Math.abs(actual - expected),
+    `${actual} not within ${tolerance} of ${expected}`
+  ).to.be.lessThan(tolerance)
+}
+
+describe('projection: tileToBBox', () => {
+  it('returns the whole world at z=0', () => {
+    const [minLon, minLat, maxLon, maxLat] = tileToBBox(0, 0, 0)
+    approx(minLon, -180)
+    approx(maxLon, 180)
+    approx(minLat, -WEB_MERCATOR_MAX_LAT, 1e-9)
+    approx(maxLat, WEB_MERCATOR_MAX_LAT, 1e-9)
+  })
+
+  it('returns the north-west quadrant at z=1,(0,0)', () => {
+    const [minLon, minLat, maxLon, maxLat] = tileToBBox(0, 0, 1)
+    approx(minLon, -180)
+    approx(maxLon, 0)
+    approx(minLat, 0, 1e-9)
+    approx(maxLat, WEB_MERCATOR_MAX_LAT, 1e-9)
+  })
+
+  it('returns the south-east quadrant at z=1,(1,1)', () => {
+    const [minLon, minLat, maxLon, maxLat] = tileToBBox(1, 1, 1)
+    approx(minLon, 0)
+    approx(maxLon, 180)
+    approx(minLat, -WEB_MERCATOR_MAX_LAT, 1e-9)
+    approx(maxLat, 0, 1e-9)
+  })
+
+  it('produces contiguous non-overlapping tiles at z=2', () => {
+    // tile (1,1,2) ends where tile (2,1,2) begins in longitude
+    const left = tileToBBox(1, 1, 2)
+    const right = tileToBBox(2, 1, 2)
+    approx(left[2], right[0])
+    // tile (1,1,2) ends where tile (1,2,2) begins in latitude (min->max)
+    const below = tileToBBox(1, 2, 2)
+    approx(left[1], below[3])
+  })
+
+  it('returns bbox as [minLon, minLat, maxLon, maxLat]', () => {
+    const bbox = tileToBBox(3, 5, 4)
+    expect(bbox[0]).to.be.lessThan(bbox[2])
+    expect(bbox[1]).to.be.lessThan(bbox[3])
+  })
+})
+
+describe('projection: lonLatToMercator', () => {
+  it('maps the origin to (0, 0)', () => {
+    const [x, y] = lonLatToMercator(0, 0)
+    approx(x, 0)
+    approx(y, 0)
+  })
+
+  it('maps lon=180 to the eastern extent', () => {
+    const [x, y] = lonLatToMercator(180, 0)
+    approx(x, WEB_MERCATOR_HALF_EXTENT_M)
+    approx(y, 0)
+  })
+
+  it('maps lon=-180 to the western extent', () => {
+    const [x] = lonLatToMercator(-180, 0)
+    approx(x, -WEB_MERCATOR_HALF_EXTENT_M)
+  })
+
+  it('maps the Web Mercator max latitude to the northern extent', () => {
+    const [, y] = lonLatToMercator(0, WEB_MERCATOR_MAX_LAT)
+    // math loses precision near the pole; allow 1m tolerance on a ~20M m value
+    approx(y, WEB_MERCATOR_HALF_EXTENT_M, 1)
+  })
+
+  it('is symmetric about the equator', () => {
+    const [, yNorth] = lonLatToMercator(0, 45)
+    const [, ySouth] = lonLatToMercator(0, -45)
+    approx(yNorth, -ySouth, 1e-6)
+  })
+
+  it('is linear in longitude at a fixed latitude', () => {
+    const [x1] = lonLatToMercator(45, 10)
+    const [x2] = lonLatToMercator(90, 10)
+    approx(x2, x1 * 2, 1e-6)
+  })
+})


### PR DESCRIPTION
## Summary

Adds `{bbox}` and `{bbox_3857}` URL substitution to the tile proxy so WMS chart sources can be proxied and cached alongside regular tile sources.

NOAA retired their RNC tile service and the Chart Display Service now serves S-57 ENC data through WMS only — no XYZ tile endpoint. This makes caching impossible with the current proxy since it only does `{z}/{x}/{y}` substitution.

Addresses #53

## What changed

- `{bbox}` replaced with `minLon,minLat,maxLon,maxLat` (EPSG:4326)
- `{bbox_3857}` replaced with the same bounds in Web Mercator
- `tileToBBox` promoted from `private` to `static` (already existed, just needed to be callable from the static `fetchTileFromRemote`)
- Small `lonLatToMercator` helper for the 3857 projection

No changes to config schema, proxy routes, or caching/seeding — those already work on tiles internally. Fully backwards compatible: the bbox logic only fires if the URL contains `{bbox}` or `{bbox_3857}`, existing configs are untouched.

## Example: NOAA S-57 ENC with caching

| Field | Value |
|---|---|
| Server type | `tilelayer` |
| Format | `png` |
| Proxy | enabled |
| URL | `https://gis.charttools.noaa.gov/arcgis/rest/services/MCS/NOAAChartDisplay/MapServer/exts/MaritimeChartService/WMSServer?service=WMS&version=1.3.0&request=GetMap&layers=0,1,2,3,4,5,6,7,8,9,10,11,12&styles=&crs=EPSG:3857&bbox={bbox_3857}&width=256&height=256&format=image/png&transparent=true` |

## Testing

- Tested on Raspberry Pi 4 running OpenPlotter / SignalK 2.19.1 with Freeboard-SK
- NOAA ENC tiles fetch, cache to disk, and serve from cache on subsequent requests
- Existing `{z}/{x}/{y}` tile sources continue to work unchanged