### PR TITLE
fix: harden tile serving with format allowlist and file validation

### DIFF
--- a/src/charts.ts
+++ b/src/charts.ts
@@ -160,12 +160,12 @@ function directoryToMapInfo(file: string, identifier: string) {
           return null
         }
         info.identifier = identifier
-        ;(info._fileFormat = 'directory'),
-          (info._filePath = file),
-          (info.v1 = {
-            tilemapUrl: `~tilePath~/${identifier}/{z}/{x}/{y}`,
-            chartLayers: []
-          })
+        info._fileFormat = 'directory'
+        info._filePath = file
+        info.v1 = {
+          tilemapUrl: `~tilePath~/${identifier}/{z}/{x}/{y}`,
+          chartLayers: []
+        }
         info.v2 = {
           url: `~tilePath~/${identifier}/{z}/{x}/{y}`,
           layers: []

--- a/src/charts.ts
+++ b/src/charts.ts
@@ -6,6 +6,7 @@ import { ChartProvider } from './types'
 import { promisify } from 'util'
 
 // Dynamically load MBTiles to prevent module load failure
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 let MBTiles: any = null
 let mbtilesLoadError: Error | null = null
 

--- a/src/charts.ts
+++ b/src/charts.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 import * as xml2js from 'xml2js'
-import { Dirent, promises as fs } from 'fs'
+import { promises as fs } from 'fs'
 import * as _ from 'lodash'
 import { ChartProvider } from './types'
 import { promisify } from 'util'

--- a/src/index.ts
+++ b/src/index.ts
@@ -479,6 +479,14 @@ const responseHttpOptions = {
   }
 }
 
+// Allowed tile file formats. Add new formats here when supporting them.
+const ALLOWED_TILE_FORMATS = new Set(['png', 'jpg', 'jpeg', 'pbf'])
+
+const isAllowedTileFormat = (format: string | undefined): boolean => {
+  if (!format) return false
+  return ALLOWED_TILE_FORMATS.has(format.toLowerCase())
+}
+
 const resolveUniqueChartPaths = (
   chartPaths: string[],
   configBasePath: string
@@ -573,18 +581,28 @@ const serveTileFromFilesystem = (
   y: number
 ) => {
   const { format, _flipY, _filePath } = provider
+  const normalizedFormat = format?.toLowerCase() ?? ''
+  if (!_filePath || !ALLOWED_TILE_FORMATS.has(normalizedFormat)) {
+    res.sendStatus(404)
+    return
+  }
   const flippedY = Math.pow(2, z) - 1 - y
-  const file = _filePath
-    ? path.resolve(_filePath, `${z}/${x}/${_flipY ? flippedY : y}.${format}`)
-    : ''
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  res.sendFile(file, responseHttpOptions, (err: any) => {
-    if (err && err.code === 'ENOENT') {
+  const file = path.resolve(
+    _filePath,
+    `${z}/${x}/${_flipY ? flippedY : y}.${normalizedFormat}`
+  )
+  try {
+    const stats = fs.statSync(file)
+    if (!stats.isFile()) {
       res.sendStatus(404)
-    } else if (err) {
-      throw err
+      return
     }
-  })
+    fs.accessSync(file, fs.constants.R_OK)
+  } catch {
+    res.sendStatus(404)
+    return
+  }
+  res.sendFile(file, responseHttpOptions)
 }
 
 const serveTileFromMbtiles = (
@@ -594,6 +612,10 @@ const serveTileFromMbtiles = (
   x: number,
   y: number
 ) => {
+  if (!isAllowedTileFormat(provider.format)) {
+    res.sendStatus(404)
+    return
+  }
   provider._mbtilesHandle.getTile(
     z,
     x,

--- a/src/index.ts
+++ b/src/index.ts
@@ -573,7 +573,7 @@ const ensureDirectoryExists = (path: string) => {
   }
 }
 
-const serveTileFromFilesystem = (
+const serveTileFromFilesystem = async (
   res: Response,
   provider: ChartProvider,
   z: number,
@@ -592,12 +592,12 @@ const serveTileFromFilesystem = (
     `${z}/${x}/${_flipY ? flippedY : y}.${normalizedFormat}`
   )
   try {
-    const stats = fs.statSync(file)
+    const stats = await fs.promises.stat(file)
     if (!stats.isFile()) {
       res.sendStatus(404)
       return
     }
-    fs.accessSync(file, fs.constants.R_OK)
+    await fs.promises.access(file, fs.constants.R_OK)
   } catch {
     res.sendStatus(404)
     return


### PR DESCRIPTION
## Summary

Hardens the two tile-serving paths (filesystem + MBTiles) so unsupported formats, unreadable files, or non-regular files return a clean 404 instead of leaking content, throwing, or 500-ing.

- Allowlist `{png, jpg, jpeg, pbf}` validated on both paths
- `statSync` / `accessSync` pre-check before `sendFile` (rejects directories and unreadable targets)
- Lowercase-normalize `format` so metadata like `"PNG"` resolves correctly on case-sensitive filesystems
- Minor cleanup in `src/charts.ts` (comma-chained assignment -> plain statements)

## Credit

Approach adapted from #52 by @herostrat. That PR bundled ~2000 lines of AI-generated tests alongside the hardening; we are taking the hardening now and will add test coverage systematically in a follow-up.

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (existing 12-test suite unchanged)
- [x] `npm run ci-lint` shows only pre-existing warnings
- [ ] Follow-up: dedicated tests for 404 scenarios (invalid format, directory as target, unreadable file, out-of-range z/x/y)