### PR TITLE
docs: add CI, npm version, and license badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Signal K server Charts plugin
 
+[![CI](https://github.com/SignalK/charts-plugin/actions/workflows/ci.yml/badge.svg)](https://github.com/SignalK/charts-plugin/actions/workflows/ci.yml)
+[![npm version](https://img.shields.io/npm/v/@signalk/charts-plugin.svg)](https://www.npmjs.com/package/@signalk/charts-plugin)
+[![License](https://img.shields.io/npm/l/@signalk/charts-plugin.svg)](https://github.com/SignalK/charts-plugin/blob/master/LICENSE)
+
 Signal K Node server plugin to provide chart metadata, such as name, description and location of the actual chart tile data.
 
 Chart metadata is derived from the following supported chart file types:


### PR DESCRIPTION
Adds the same three-badge row already on the four family repos ([nmea0183-signalk](https://github.com/SignalK/nmea0183-signalk#readme), [nmea0183-utilities](https://github.com/SignalK/nmea0183-utilities#readme), [signalk-to-nmea0183](https://github.com/SignalK/signalk-to-nmea0183#readme), [signalk-derived-data](https://github.com/SignalK/signalk-derived-data#readme)) right under the H1:

- **CI** — GitHub's native workflow badge for `ci.yml`. Auto-refreshes on every CI run, no polling step.
- **npm version** — `img.shields.io/npm/v` against `@signalk/charts-plugin`. Reads npm's registry directly.
- **License** — `img.shields.io/npm/l` against `@signalk/charts-plugin`.

README-only, four-line change, zero external account dependencies, zero runtime impact. Badge URLs follow the exact pattern already used by the other repos so the family stays visually consistent.