### PR TITLE
chore: add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+updates:
+  # npm: weekly bumps, groups minor+patch into one PR, majors individual
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+    labels:
+      - dependencies
+
+  # GitHub Actions: weekly, one grouped PR for everything
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      actions:
+        update-types:
+          - minor
+          - patch
+          - major
+    labels:
+      - dependencies


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` mirroring the config already used in the other four maintained SK repos (`nmea0183-signalk`, `nmea0183-utilities`, `signalk-to-nmea0183`, `signalk-derived-data`): weekly npm updates with minor+patch grouped, majors individual, and a weekly grouped GitHub Actions update.
- The `dependencies` label already exists in this repo.

## Test plan
- [ ] Dependabot picks up the config and opens its first PR on the next weekly run.