### PR TITLE
fix: pre-release correctness and performance pass

### DIFF
--- a/src/chartDownloader.ts
+++ b/src/chartDownloader.ts
@@ -16,7 +16,7 @@ import { polygon } from '@turf/helpers'
 import checkDiskSpace from 'check-disk-space'
 import { ResourcesApi } from '@signalk/server-api'
 import { ChartProvider } from './types'
-import { lonLatToMercator, tileToBBox } from './projection'
+import { lonLatToMercator, lonLatToTile, tileToBBox } from './projection'
 
 export interface Tile {
   x: number
@@ -37,18 +37,30 @@ export class ChartSeedingManager {
     chartsPath: string,
     provider: ChartProvider,
     maxZoom: number,
-    regionGUI: string | undefined = undefined,
+    regionGUID: string | undefined = undefined,
     bbox: BBox | undefined = undefined,
     tile: Tile | undefined = undefined
   ): Promise<ChartDownloader> {
     const downloader = new ChartDownloader(resourcesApi, chartsPath, provider)
-    if (regionGUI) downloader.initalizeJobFromRegion(regionGUI, maxZoom)
-    else if (bbox) downloader.initializeJobFromBBox(bbox, maxZoom)
-    else if (tile) {
-      downloader.initializeJobFromTile(tile, maxZoom)
-    }
+    // Init must complete before the job is usable; callers get back a job that
+    // knows its tile set and totalTiles. Without awaiting, a follow-up "start"
+    // action would race the init reads of this.tiles.
+    if (regionGUID)
+      await downloader.initializeJobFromRegion(regionGUID, maxZoom)
+    else if (bbox) await downloader.initializeJobFromBBox(bbox, maxZoom)
+    else if (tile) await downloader.initializeJobFromTile(tile, maxZoom)
+    else throw new Error('createJob requires regionGUID, bbox, or tile')
     this.ActiveJobs[downloader.ID] = downloader
     return downloader
+  }
+
+  // Cancel all running jobs and clear the registry. Used when the plugin stops
+  // so a disabled plugin doesn't keep pulling tiles in the background.
+  public static cancelAll(): void {
+    for (const job of Object.values(this.ActiveJobs)) {
+      job.cancelJob()
+    }
+    this.ActiveJobs = {}
   }
 }
 
@@ -81,7 +93,7 @@ export class ChartDownloader {
     return this.id
   }
 
-  public async initalizeJobFromRegion(
+  public async initializeJobFromRegion(
     regionGUID: string,
     maxZoom: number
   ): Promise<void> {
@@ -137,6 +149,10 @@ export class ChartDownloader {
    *
    */
   async seedCache(): Promise<void> {
+    // Guard against double-start: a second call while Running would share
+    // counters and concurrency slots with the first and corrupt progress.
+    if (this.status === Status.Running) return
+
     this.cancelRequested = false
     this.status = Status.Running
     this.tilesToDownload = await this.filterCachedTiles(this.tiles)
@@ -145,26 +161,22 @@ export class ChartDownloader {
     this.cachedTiles = this.totalTiles - this.tilesToDownload.length
     const limit = pLimit(this.concurrentDownloadsLimit) // concurrent download limit
     let tileCounter = 0
-    this.tilesToDownload = await this.filterCachedTiles(this.tiles)
 
     const tasks = this.tilesToDownload.map((tile) =>
       limit(async () => {
-        if (this.cancelRequested) {
-          this.status = Status.Stopped
-          return
-        }
+        if (this.cancelRequested) return
         if (tileCounter % 1000 === 0) {
           await new Promise((r) => setTimeout(r, 0))
           try {
             const { free } = await checkDiskSpace(this.chartsPath)
             if (free < ChartDownloader.MINIMUM_FREE_DISK_SPACE) {
               console.warn(`Low disk space. Stopping download.`)
-              this.status = Status.Stopped
+              this.cancelRequested = true
               return
             }
           } catch (err) {
             console.error(`Error checking disk space:`, err)
-            this.status = Status.Stopped
+            this.cancelRequested = true
             return
           }
         }
@@ -174,6 +186,10 @@ export class ChartDownloader {
           this.provider,
           tile
         )
+        // Re-check after the await: the job may have been cancelled while the
+        // fetch was in flight. Still-running fetches would otherwise keep
+        // mutating counters after status flips to Stopped.
+        if (this.cancelRequested) return
         if (buffer === null) {
           this.failedTiles++
         } else {
@@ -219,26 +235,32 @@ export class ChartDownloader {
   }
 
   private async filterCachedTiles(allTiles: Tile[]): Promise<Tile[]> {
-    const checks = allTiles.map(async (tile) => {
-      const tilePath = path.join(
-        this.chartsPath,
-        this.provider.name,
-        `${tile.z}`,
-        `${tile.x}`,
-        `${tile.y}.${this.provider.format}`
-      )
+    // Bound the concurrent fs.access calls. 100k+ tiles in a large bbox would
+    // otherwise fire all accesses at once, risking EMFILE on default rlimit
+    // and spiking the event loop.
+    const limit = pLimit(64)
+    const checks = allTiles.map((tile) =>
+      limit(async () => {
+        const tilePath = path.join(
+          this.chartsPath,
+          this.provider.name,
+          `${tile.z}`,
+          `${tile.x}`,
+          `${tile.y}.${this.provider.format}`
+        )
 
-      try {
-        await fs.promises.access(tilePath) // file exists
-        return null // filter out cached tile
-      } catch (err: unknown) {
-        if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
-          return tile // file does not exist → uncached
+        try {
+          await fs.promises.access(tilePath) // file exists
+          return null // filter out cached tile
+        } catch (err: unknown) {
+          if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+            return tile // file does not exist → uncached
+          }
+          console.error('Unexpected fs error:', err)
+          return tile // treat unknown errors as uncached
         }
-        console.error('Unexpected fs error:', err)
-        return tile // treat unknown errors as uncached
-      }
-    })
+      })
+    )
 
     const results = await Promise.all(checks)
     return results.filter((t): t is Tile => t !== null)
@@ -379,17 +401,22 @@ export class ChartDownloader {
     const [minLon, minLat, maxLon, maxLat] = bbox
 
     const crossesAntiMeridian = minLon > maxLon
+    // Respect the provider's minzoom: low zooms outside the provider's range
+    // would 404 from the remote and just inflate totalTiles.
+    const minZoom = Math.max(1, this.provider.minzoom ?? 1)
 
-    // Helper to process a lon/lat box normally
+    // Helper to process a lon/lat box normally. lonLatToTileXY returns
+    // tile-Y increasing southward, so for a box with minLat < maxLat the
+    // south edge yields the larger tile-Y.
     const processBBox = (
       lo1: number,
       la1: number,
       lo2: number,
       la2: number
     ) => {
-      for (let z = 0; z <= maxZoom; z++) {
-        const [minX, maxY] = this.lonLatToTileXY(lo1, la1, z)
-        const [maxX, minY] = this.lonLatToTileXY(lo2, la2, z)
+      for (let z = minZoom; z <= maxZoom; z++) {
+        const [minX, maxY] = lonLatToTile(lo1, la1, z) // SW corner
+        const [maxX, minY] = lonLatToTile(lo2, la2, z) // NE corner
 
         for (let x = minX; x <= maxX; x++) {
           for (let y = minY; y <= maxY; y++) {
@@ -430,22 +457,30 @@ export class ChartDownloader {
 
       const boundingBox = bbox(feature.geometry as Polygon) // [minX, minY, maxX, maxY]
       for (let z = zoomMin; z <= zoomMax; z++) {
-        const [minX, minY] = this.lonLatToTileXY(
-          boundingBox[0],
-          boundingBox[3],
-          z
-        ) // top-left
-        const [maxX, maxY] = this.lonLatToTileXY(
-          boundingBox[2],
-          boundingBox[1],
-          z
-        ) // bottom-right
+        const [minX, minY] = lonLatToTile(boundingBox[0], boundingBox[3], z) // top-left
+        const [maxX, maxY] = lonLatToTile(boundingBox[2], boundingBox[1], z) // bottom-right
 
         for (let x = minX; x <= maxX; x++) {
           for (let y = minY; y <= maxY; y++) {
-            const tileBbox = tileToBBox(x, y, z)
-            const tilePoly = this.bboxPolygon(tileBbox)
-
+            // Cheap AABB pre-filter avoids allocating a turf polygon and
+            // running booleanIntersects for tiles that can't possibly
+            // overlap the feature's bbox. Saves 90%+ of the turf work on
+            // concave regions.
+            const [tMinLon, tMinLat, tMaxLon, tMaxLat] = tileToBBox(x, y, z)
+            if (
+              tMaxLon < boundingBox[0] ||
+              tMinLon > boundingBox[2] ||
+              tMaxLat < boundingBox[1] ||
+              tMinLat > boundingBox[3]
+            ) {
+              continue
+            }
+            const tilePoly = this.bboxPolygon([
+              tMinLon,
+              tMinLat,
+              tMaxLon,
+              tMaxLat
+            ])
             if (booleanIntersects(feature as Feature, tilePoly)) {
               tiles.push({ x, y, z })
             }
@@ -521,25 +556,6 @@ export class ChartDownloader {
       type: 'FeatureCollection' as const,
       features
     }
-  }
-
-  private lonLatToTileXY(
-    lon: number,
-    lat: number,
-    zoom: number
-  ): [number, number] {
-    const n = 2 ** zoom
-    const x = Math.floor(((lon + 180) / 360) * n)
-    const y = Math.floor(
-      ((1 -
-        Math.log(
-          Math.tan((lat * Math.PI) / 180) + 1 / Math.cos((lat * Math.PI) / 180)
-        ) /
-          Math.PI) /
-        2) *
-        n
-    )
-    return [x, y]
   }
 
   private bboxPolygon(boundingBox: BBox) {

--- a/src/charts.ts
+++ b/src/charts.ts
@@ -2,6 +2,7 @@ import path from 'path'
 import * as xml2js from 'xml2js'
 import { Dirent, promises as fs } from 'fs'
 import * as _ from 'lodash'
+import pLimit from 'p-limit'
 import { ChartProvider } from './types'
 import { promisify } from 'util'
 
@@ -30,29 +31,31 @@ async function loadMBTiles() {
 // else is descended into so layouts like charts/<region>/<chart> work without
 // having to list every subdir in the plugin config. Symlinks are skipped and
 // the depth is bounded so a misplaced config entry can't send the scan into
-// node_modules or a symlink loop.
+// node_modules or a symlink loop. File parsing (openMbtilesFile /
+// directoryToMapInfo) runs concurrently under a global limiter — 500 MBTiles
+// opened serially on a Pi SD card was a 5-30s startup stall.
 const MAX_SCAN_DEPTH = 8
+const PARSE_CONCURRENCY = 12
 
 export async function findCharts(
   chartBaseDir: string
 ): Promise<{ [identifier: string]: ChartProvider }> {
   await loadMBTiles()
   const charts: ChartProvider[] = []
-  await scanDir(chartBaseDir, charts, 0)
-  return _.reduce(
-    charts,
-    (result, chart) => {
-      result[chart.identifier] = chart
-      return result
-    },
-    {} as { [identifier: string]: ChartProvider }
-  )
+  const limit = pLimit(PARSE_CONCURRENCY)
+  await scanDir(chartBaseDir, charts, 0, limit)
+  const result: { [identifier: string]: ChartProvider } = {}
+  for (const chart of charts) {
+    result[chart.identifier] = chart
+  }
+  return result
 }
 
 async function scanDir(
   dir: string,
   out: ChartProvider[],
-  depth: number
+  depth: number,
+  limit: ReturnType<typeof pLimit>
 ): Promise<void> {
   if (depth > MAX_SCAN_DEPTH) return
   let entries: Dirent[]
@@ -64,6 +67,11 @@ async function scanDir(
     )
     return
   }
+  // Directory recursion runs outside the limiter to avoid deadlock: a parent
+  // holding a slot while waiting for children to take their own slots would
+  // starve when the limit is reached. Only the leaf file-parsing work
+  // (openMbtilesFile / directoryToMapInfo) is rate-limited.
+  const tasks: Promise<void>[] = []
   for (const entry of entries) {
     if (entry.isSymbolicLink()) continue
     const entryPath = path.resolve(dir, entry.name)
@@ -74,17 +82,30 @@ async function scanDir(
         )
         continue
       }
-      const chart = await openMbtilesFile(entryPath, entry.name)
-      if (chart) out.push(chart as ChartProvider)
+      tasks.push(
+        (async () => {
+          const chart = await limit(() =>
+            openMbtilesFile(entryPath, entry.name)
+          )
+          if (chart) out.push(chart as ChartProvider)
+        })()
+      )
     } else if (entry.isDirectory()) {
-      const chart = await directoryToMapInfo(entryPath, entry.name)
-      if (chart) {
-        out.push(chart as ChartProvider)
-      } else {
-        await scanDir(entryPath, out, depth + 1)
-      }
+      tasks.push(
+        (async () => {
+          const chart = await limit(() =>
+            directoryToMapInfo(entryPath, entry.name)
+          )
+          if (chart) {
+            out.push(chart as ChartProvider)
+          } else {
+            await scanDir(entryPath, out, depth + 1, limit)
+          }
+        })()
+      )
     }
   }
+  await Promise.all(tasks)
 }
 
 function openMbtilesFile(file: string, filename: string) {
@@ -192,7 +213,7 @@ function directoryToMapInfo(file: string, identifier: string) {
     })
     .catch((e) => {
       console.error(`Error getting charts from ${file}`, e.message)
-      return undefined
+      return null
     })
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,9 +40,17 @@ const chartTilesPath = '/signalk/chart-tiles'
 const RELOAD_DEBOUNCE_MS =
   Number(process.env.SK_CHARTS_RELOAD_DEBOUNCE_MS) || 5000
 
+type SanitizedProvider = Record<string, unknown>
+
 module.exports = (app: ChartProviderApp): Plugin => {
   let chartProviders: { [key: string]: ChartProvider } = {}
+  // Pre-computed per-version views of chartProviders, rebuilt on every reload.
+  // The HTTP handlers serve directly from here so tile-list requests don't pay
+  // a deep clone per provider on the hot path.
+  let sanitizedV1: { [key: string]: SanitizedProvider } = {}
+  let sanitizedV2: { [key: string]: SanitizedProvider } = {}
   let pluginStarted = false
+  let providerRegistered = false
   let props: Config = {
     chartPaths: [],
     cachePath: '',
@@ -55,7 +63,6 @@ module.exports = (app: ChartProviderApp): Plugin => {
   const serverMajorVersion = app.config.version
     ? parseInt(app.config.version.split('.')[0])
     : '1'
-  ensureDirectoryExists(defaultChartsPath)
 
   let cachePath = defaultChartsPath
 
@@ -214,6 +221,9 @@ module.exports = (app: ChartProviderApp): Plugin => {
     },
     stop: () => {
       stopWatchers()
+      // Cancel any running seeding jobs so a disabled plugin doesn't keep
+      // pulling tiles from remote providers in the background.
+      ChartSeedingManager.cancelAll()
       // Close open SQLite connections so the user can move or delete chart
       // files while the plugin is stopped (Windows blocks deletion on open
       // handles). Restart re-opens fresh via findCharts.
@@ -221,11 +231,13 @@ module.exports = (app: ChartProviderApp): Plugin => {
         if (p?._mbtilesHandle) closeMbtilesHandle(p._mbtilesHandle)
       }
       chartProviders = {}
+      sanitizedV1 = {}
+      sanitizedV2 = {}
       app.setPluginStatus('stopped')
     }
   }
 
-  const doStartup = (config: Config) => {
+  const doStartup = async (config: Config) => {
     // Check Node version
     const nodeVersion = process.versions.node
     const majorVersion = parseInt(nodeVersion.split('.')[0])
@@ -248,31 +260,41 @@ module.exports = (app: ChartProviderApp): Plugin => {
       ? [defaultChartsPath]
       : resolveUniqueChartPaths(props.chartPaths, configBasePath)
     cachePath = props.cachePath || defaultChartsPath
-    ensureDirectoryExists(cachePath)
+    // Both paths commonly coincide on a fresh install; ensure they exist once
+    // here rather than at plugin construction time, which kept us off the
+    // sync-fs path at module load.
+    await ensureDirectoryExists(defaultChartsPath)
+    if (cachePath !== defaultChartsPath) {
+      await ensureDirectoryExists(cachePath)
+    }
 
-    activeOnlineProviders = _.reduce(
-      props.onlineChartProviders,
-      (result: { [key: string]: object }, data) => {
-        const provider = convertOnlineProviderConfig(data)
-        result[provider.identifier] = provider
-        return result
-      },
-      {}
-    )
+    activeOnlineProviders = {}
+    for (const data of props.onlineChartProviders ?? []) {
+      const provider = convertOnlineProviderConfig(data)
+      if (activeOnlineProviders[provider.identifier]) {
+        app.debug(
+          `Duplicate online provider identifier "${provider.identifier}" ` +
+            `(from name "${data.name}"); the later entry wins. ` +
+            `Rename one of the providers to avoid the collision.`
+        )
+      }
+      activeOnlineProviders[provider.identifier] = provider
+    }
     app.debug(
       `Start charts plugin. Chart paths: ${activeChartPaths.join(
         ', '
       )}, online charts: ${Object.keys(activeOnlineProviders).length}`
     )
 
-    // Do not register routes if plugin has been started once already
-    pluginStarted === false && registerRoutes()
+    // Routes and the v2 provider registration are idempotent — Signal K can
+    // call start() again after a config change, but re-registering would
+    // either throw or duplicate the handler.
+    if (!pluginStarted) registerRoutes()
     pluginStarted = true
-
-    // v2 routes - register as Resource Provider, this needs to be always on startup
-    if (serverMajorVersion === 2) {
+    if (serverMajorVersion === 2 && !providerRegistered) {
       app.debug('** Registering v2 API paths **')
       registerAsProvider()
+      providerRegistered = true
     }
 
     app.setPluginStatus('Started')
@@ -282,21 +304,13 @@ module.exports = (app: ChartProviderApp): Plugin => {
   }
 
   const loadChartProviders = async (): Promise<void> => {
-    let newCharts: { [key: string]: ChartProvider } = {}
+    // Scan configured chart paths in parallel. findCharts already bounds its
+    // own per-file concurrency internally, so kicking off multiple roots at
+    // once just overlaps their directory reads.
+    let results: ({ [key: string]: ChartProvider } | undefined)[]
     try {
-      const list: ({ [key: string]: ChartProvider } | undefined)[] = []
-      for (const chartPath of activeChartPaths) {
-        list.push(await findCharts(chartPath))
-      }
-      newCharts = _.reduce(
-        list,
-        (result, c) => _.merge({}, result, c),
-        {} as { [key: string]: ChartProvider }
-      )
-      app.debug(
-        `Chart plugin: Found ${
-          _.keys(newCharts).length
-        } charts from ${activeChartPaths.join(', ')}.`
+      results = await Promise.all(
+        activeChartPaths.map((chartPath) => findCharts(chartPath))
       )
     } catch (e) {
       // Keep the last-good chartProviders instead of wiping everything - a
@@ -307,45 +321,74 @@ module.exports = (app: ChartProviderApp): Plugin => {
       return
     }
 
-    reconcileMbtilesHandles(chartProviders, newCharts)
-    chartProviders = _.merge({}, newCharts, activeOnlineProviders)
+    // Identifier is the source of uniqueness: a deep-merge here would cost
+    // O(N²) property copies for identical keys while adding nothing over a
+    // plain shallow assignment.
+    const newCharts: { [key: string]: ChartProvider } = {}
+    for (const r of results) {
+      if (!r) continue
+      for (const [id, chart] of Object.entries(r)) {
+        if (newCharts[id]) {
+          app.debug(
+            `Duplicate chart identifier "${id}" from multiple chart paths; ` +
+              `the later one wins.`
+          )
+        }
+        newCharts[id] = chart
+      }
+    }
+    app.debug(
+      `Chart plugin: Found ${
+        Object.keys(newCharts).length
+      } charts from ${activeChartPaths.join(', ')}.`
+    )
+
+    reconcileMbtilesHandles(chartProviders)
+    // Shallow assign is enough: newCharts and activeOnlineProviders both
+    // have unique ids per entry; the values themselves are used by reference.
+    chartProviders = { ...newCharts }
+    for (const [id, provider] of Object.entries(activeOnlineProviders)) {
+      if (chartProviders[id]) {
+        app.debug(
+          `Online provider identifier "${id}" collides with a local chart; ` +
+            `the online provider wins.`
+        )
+      }
+      chartProviders[id] = provider as ChartProvider
+    }
+    buildSanitizedCache()
     app.setPluginStatus(
-      `Started - ${_.keys(chartProviders).length} chart(s) loaded`
+      `Started - ${Object.keys(chartProviders).length} chart(s) loaded`
     )
   }
 
-  // When a file is still present across a reload, reuse the existing SQLite
-  // handle instead of the freshly-opened one from findCharts. Closes handles
-  // for files that have gone away. Without this, every reload leaks a SQLite
-  // connection per MBTiles file.
-  const reconcileMbtilesHandles = (
-    oldSet: { [key: string]: ChartProvider },
-    newSet: { [key: string]: ChartProvider }
-  ) => {
-    const newPaths = new Set<string>()
-    for (const p of Object.values(newSet)) {
-      if (p?._filePath) newPaths.add(p._filePath)
+  // Rebuilds the per-version sanitized views. Called once per reload so the
+  // HTTP handlers can hand out pre-built dictionaries instead of deep-cloning
+  // every provider on every metadata request.
+  const buildSanitizedCache = () => {
+    sanitizedV1 = {}
+    sanitizedV2 = {}
+    for (const [id, provider] of Object.entries(chartProviders)) {
+      sanitizedV1[id] = sanitizeProvider(provider, 1)
+      sanitizedV2[id] = sanitizeProvider(provider, 2)
     }
-    for (const [id, n] of Object.entries(newSet)) {
-      const old = oldSet[id]
-      if (
-        n?._mbtilesHandle &&
-        old?._mbtilesHandle &&
-        old._filePath === n._filePath
-      ) {
-        // Drop the newly-opened handle; reuse the existing one so in-flight
-        // requests that captured a reference keep working.
-        closeMbtilesHandle(n._mbtilesHandle)
-        n._mbtilesHandle = old._mbtilesHandle
-      }
-    }
+  }
+
+  // Close every old MBTiles handle after a reload. findCharts opened fresh
+  // handles for every file that still exists, so the NEW set reflects current
+  // content — including files that were replaced in place (same filename,
+  // new content). Reusing the old handle in that case would serve stale tiles
+  // from SQLite's cached pages. Close is delayed so an in-flight tile request
+  // that captured a reference has time to complete before the handle goes
+  // away; 1s is well above realistic tile-serve latency.
+  const MBTILES_CLOSE_DELAY_MS = 1000
+  const reconcileMbtilesHandles = (oldSet: {
+    [key: string]: ChartProvider
+  }) => {
     for (const old of Object.values(oldSet)) {
-      if (
-        old?._mbtilesHandle &&
-        old._filePath &&
-        !newPaths.has(old._filePath)
-      ) {
-        closeMbtilesHandle(old._mbtilesHandle)
+      if (old?._mbtilesHandle) {
+        const handle = old._mbtilesHandle
+        setTimeout(() => closeMbtilesHandle(handle), MBTILES_CLOSE_DELAY_MS)
       }
     }
   }
@@ -476,28 +519,38 @@ module.exports = (app: ChartProviderApp): Plugin => {
         }
         const provider = chartProviders[identifier]
         if (!provider) {
-          return res.sendStatus(500).send('Provider not found')
+          return res.status(404).send('Provider not found')
         }
         if (!maxZoom) {
           return res.status(400).send('maxZoom parameter is required')
         }
+        if (!regionGUID && !bbox && !tile) {
+          return res
+            .status(400)
+            .send('Request must include regionGUID, bbox, or tile')
+        }
         const maxZoomParsed = parseInt(maxZoom)
-        await ChartSeedingManager.createJob(
-          app.resourcesApi,
-          cachePath,
-          provider,
-          maxZoomParsed,
-          regionGUID,
-          bbox
-            ? [bbox.minLon, bbox.minLat, bbox.maxLon, bbox.maxLat]
-            : undefined,
-          tile
-        )
-        return res.status(200).json({
-          state: 'COMPLETED',
-          statusCode: 200,
-          message: 'OK'
-        })
+        try {
+          const job = await ChartSeedingManager.createJob(
+            app.resourcesApi,
+            cachePath,
+            provider,
+            maxZoomParsed,
+            regionGUID,
+            bbox
+              ? [bbox.minLon, bbox.minLat, bbox.maxLon, bbox.maxLat]
+              : undefined,
+            tile
+          )
+          // Job is registered and its tile set is known, but nothing has been
+          // downloaded yet — the caller starts it with
+          // POST /cache/jobs/:id { action: 'start' }.
+          return res.status(202).json(job.info())
+        } catch (err) {
+          return res
+            .status(500)
+            .send(`Failed to create seeding job: ${(err as Error).message}`)
+        }
       }
     )
 
@@ -514,21 +567,28 @@ module.exports = (app: ChartProviderApp): Plugin => {
         const { id } = req.params
         const { action } = req.body as { action: string }
         const parsedId = parseInt(id)
-        const job = ChartSeedingManager.ActiveJobs[parsedId]
-        if (job && action) {
-          if (action === 'start') {
-            job.seedCache()
-          } else if (action === 'stop') {
-            job.cancelJob()
-          } else if (action === 'delete') {
-            job.deleteCache()
-          } else if (action === 'remove') {
-            delete ChartSeedingManager.ActiveJobs[parsedId]
-          } else {
-            return res.status(404).send(`Job ${parsedId} not found`)
-          }
-          return res.status(200).send(`Job ${parsedId} ${action}ed`)
+        if (!Number.isFinite(parsedId)) {
+          return res.status(400).send(`Invalid job id: ${id}`)
         }
+        const job = ChartSeedingManager.ActiveJobs[parsedId]
+        if (!job) {
+          return res.status(404).send(`Job ${parsedId} not found`)
+        }
+        if (!action) {
+          return res.status(400).send('action parameter is required')
+        }
+        if (action === 'start') {
+          job.seedCache()
+        } else if (action === 'stop') {
+          job.cancelJob()
+        } else if (action === 'delete') {
+          job.deleteCache()
+        } else if (action === 'remove') {
+          delete ChartSeedingManager.ActiveJobs[parsedId]
+        } else {
+          return res.status(400).send(`Unknown action: ${action}`)
+        }
+        return res.status(200).send(`Job ${parsedId} ${action}ed`)
       }
     )
 
@@ -538,9 +598,9 @@ module.exports = (app: ChartProviderApp): Plugin => {
       apiRoutePrefix[1] + '/charts/:identifier',
       (req: Request, res: Response) => {
         const { identifier } = req.params
-        const provider = chartProviders[identifier]
-        if (provider) {
-          return res.json(sanitizeProvider(provider))
+        const view = sanitizedV1[identifier]
+        if (view) {
+          return res.json(view)
         } else {
           return res.status(404).send('Not found')
         }
@@ -548,10 +608,7 @@ module.exports = (app: ChartProviderApp): Plugin => {
     )
 
     app.get(apiRoutePrefix[1] + '/charts', (req: Request, res: Response) => {
-      const sanitized = _.mapValues(chartProviders, (provider) =>
-        sanitizeProvider(provider)
-      )
-      res.json(sanitized)
+      res.json(sanitizedV1)
     })
   }
 
@@ -566,17 +623,13 @@ module.exports = (app: ChartProviderApp): Plugin => {
             [key: string]: number | string | object | null
           }) => {
             app.debug(`** listResources() ${params}`)
-            return Promise.resolve(
-              _.mapValues(chartProviders, (provider) =>
-                sanitizeProvider(provider, 2)
-              )
-            )
+            return Promise.resolve(sanitizedV2)
           },
           getResource: (id: string) => {
             app.debug(`** getResource() ${id}`)
-            const provider = chartProviders[id]
-            if (provider) {
-              return Promise.resolve(sanitizeProvider(provider, 2))
+            const view = sanitizedV2[id]
+            if (view) {
+              return Promise.resolve(view)
             } else {
               throw new Error('Chart not found!')
             }
@@ -591,7 +644,11 @@ module.exports = (app: ChartProviderApp): Plugin => {
         }
       })
     } catch (error) {
-      app.debug('Failed Provider Registration!')
+      app.setPluginError(
+        `Failed to register as charts resource provider: ${
+          (error as Error).message
+        }`
+      )
     }
   }
 
@@ -692,30 +749,40 @@ const convertOnlineProviderConfig = (provider: OnlineChartProvider) => {
   return data
 }
 
-const sanitizeProvider = (provider: ChartProvider, version = 1) => {
-  let v
-  if (version === 1) {
-    v = _.merge({}, provider.v1)
-    v.tilemapUrl = v.tilemapUrl.replace('~tilePath~', chartTilesPath)
-  } else if (version === 2) {
-    v = _.merge({}, provider.v2)
-    v.url = v.url ? v.url.replace('~tilePath~', chartTilesPath) : ''
+// Builds the outward-facing view of a provider for either the v1 or v2 API.
+// Copies non-private top-level fields, then overlays the version-specific
+// block (v1 has tilemapUrl/chartLayers, v2 has url/layers), rewriting the
+// tile-path placeholder. Intentionally a single shallow walk — the previous
+// implementation did three deep clones per call and ran per metadata request.
+const sanitizeProvider = (
+  provider: ChartProvider,
+  version: 1 | 2 = 1
+): SanitizedProvider => {
+  const out: SanitizedProvider = {}
+  for (const [key, value] of Object.entries(provider)) {
+    if (key.startsWith('_') || key === 'v1' || key === 'v2') continue
+    out[key] = value
   }
-  provider = _.omit(provider, [
-    '_filePath',
-    '_fileFormat',
-    '_mbtilesHandle',
-    '_flipY',
-    'v1',
-    'v2'
-  ]) as ChartProvider
-  return _.merge(provider, v)
+  const v = version === 1 ? provider.v1 : provider.v2
+  if (v) {
+    for (const [key, value] of Object.entries(v)) {
+      out[key] = value
+    }
+  }
+  if (version === 1 && typeof out.tilemapUrl === 'string') {
+    out.tilemapUrl = out.tilemapUrl.replace('~tilePath~', chartTilesPath)
+  } else if (version === 2 && typeof out.url === 'string') {
+    out.url = out.url.replace('~tilePath~', chartTilesPath)
+  } else if (version === 2) {
+    out.url = ''
+  }
+  return out
 }
 
-const ensureDirectoryExists = (path: string) => {
-  if (!fs.existsSync(path)) {
-    fs.mkdirSync(path)
-  }
+const ensureDirectoryExists = async (p: string) => {
+  // mkdir with recursive:true is idempotent and skips the existsSync probe,
+  // keeping startup off the sync-fs path.
+  await fs.promises.mkdir(p, { recursive: true })
 }
 
 const serveTileFromFilesystem = async (
@@ -759,6 +826,14 @@ const serveTileFromMbtiles = (
 ) => {
   if (!isAllowedTileFormat(provider.format)) {
     res.sendStatus(404)
+    return
+  }
+  // Guard against a provider whose MBTiles handle is missing: openMbtilesFile
+  // may have failed post-reconcile, or the handle was closed while a request
+  // was in flight. Without this check, `.getTile` throws synchronously and
+  // Express never answers the client.
+  if (!provider._mbtilesHandle) {
+    res.sendStatus(500)
     return
   }
   provider._mbtilesHandle.getTile(

--- a/src/projection.ts
+++ b/src/projection.ts
@@ -4,6 +4,11 @@ import type { BBox } from 'geojson'
 // Used to scale lon/lat into Web Mercator x/y.
 export const WEB_MERCATOR_HALF_EXTENT_M = 20037508.34
 
+// Web Mercator is undefined at the poles. This is the symmetric latitude
+// where the projection maps to ±WEB_MERCATOR_HALF_EXTENT_M, also the clamp
+// limit used by OSM / Google / MapBox tile schemes.
+export const WEB_MERCATOR_MAX_LAT = 85.0511287798
+
 export function tileToBBox(x: number, y: number, z: number): BBox {
   const n = 2 ** z
   const lon1 = (x / n) * 360 - 180
@@ -20,4 +25,31 @@ export function lonLatToMercator(lon: number, lat: number): [number, number] {
   const yDeg =
     Math.log(Math.tan(((90 + lat) * Math.PI) / 360)) / (Math.PI / 180)
   return [x, (yDeg * WEB_MERCATOR_HALF_EXTENT_M) / 180]
+}
+
+// Converts lon/lat to an XYZ tile coordinate at the given zoom. Latitude is
+// clamped to WEB_MERCATOR_MAX_LAT: without that clamp, tan(π/2) at ±90 blows
+// up to Infinity and floor(NaN) leaks NaN into the tile list.
+export function lonLatToTile(
+  lon: number,
+  lat: number,
+  zoom: number
+): [number, number] {
+  const n = 2 ** zoom
+  const clampedLat = Math.max(
+    -WEB_MERCATOR_MAX_LAT,
+    Math.min(WEB_MERCATOR_MAX_LAT, lat)
+  )
+  const x = Math.floor(((lon + 180) / 360) * n)
+  const y = Math.floor(
+    ((1 -
+      Math.log(
+        Math.tan((clampedLat * Math.PI) / 180) +
+          1 / Math.cos((clampedLat * Math.PI) / 180)
+      ) /
+        Math.PI) /
+      2) *
+      n
+  )
+  return [x, y]
 }

--- a/test/plugin-test.ts
+++ b/test/plugin-test.ts
@@ -305,6 +305,147 @@ describe('chart folder watcher', function () {
   })
 })
 
+describe('tile cache HTTP endpoints', () => {
+  let plugin: PluginInstance
+  let testServer: http.Server
+  const proxyProvider = {
+    name: 'Proxy Test',
+    minzoom: 3,
+    maxzoom: 5,
+    format: 'png',
+    url: 'https://example.com/{z}/{x}/{y}.png',
+    proxy: true
+  }
+
+  beforeEach(() =>
+    createDefaultApp().then(({ app, server }) => {
+      plugin = Plugin(app)
+      testServer = server
+    })
+  )
+  afterEach(done => {
+    if (plugin && plugin.stop) plugin.stop()
+    testServer.close(() => done())
+  })
+
+  it('POST /cache/:identifier returns 404 when the provider is unknown', async () => {
+    await plugin.start({ onlineChartProviders: [proxyProvider] })
+    const res = await chai
+      .request(`http://localhost:${serverPort(testServer)}`)
+      .post('/signalk/chart-tiles/cache/does-not-exist')
+      .send({ maxZoom: '5', bbox: { minLon: 0, minLat: 0, maxLon: 1, maxLat: 1 } })
+      .catch(e => e.response)
+    expect(res.status).to.equal(404)
+  })
+
+  it('POST /cache/:identifier returns 400 when maxZoom is missing', async () => {
+    await plugin.start({ onlineChartProviders: [proxyProvider] })
+    const res = await chai
+      .request(`http://localhost:${serverPort(testServer)}`)
+      .post('/signalk/chart-tiles/cache/proxy-test')
+      .send({ bbox: { minLon: 0, minLat: 0, maxLon: 1, maxLat: 1 } })
+      .catch(e => e.response)
+    expect(res.status).to.equal(400)
+  })
+
+  it('POST /cache/:identifier returns 400 when no region/bbox/tile is given', async () => {
+    await plugin.start({ onlineChartProviders: [proxyProvider] })
+    const res = await chai
+      .request(`http://localhost:${serverPort(testServer)}`)
+      .post('/signalk/chart-tiles/cache/proxy-test')
+      .send({ maxZoom: '5' })
+      .catch(e => e.response)
+    expect(res.status).to.equal(400)
+  })
+
+  it('POST /cache/:identifier returns 202 with the fully-initialised job info', async () => {
+    await plugin.start({ onlineChartProviders: [proxyProvider] })
+    const res = await chai
+      .request(`http://localhost:${serverPort(testServer)}`)
+      .post('/signalk/chart-tiles/cache/proxy-test')
+      .send({ maxZoom: '5', bbox: { minLon: 0, minLat: 0, maxLon: 1, maxLat: 1 } })
+    expect(res.status).to.equal(202)
+    expect(res.body).to.include.keys(['id', 'totalTiles', 'status'])
+    // Init must have completed before the response: totalTiles is non-zero,
+    // which proves the tile set is populated.
+    expect(res.body.totalTiles).to.be.greaterThan(0)
+    // Job should not be auto-started — seeding is an explicit follow-up.
+    expect(res.body.downloadedTiles).to.equal(0)
+  })
+
+  it('POST /cache/:identifier with bbox respects the provider minzoom', async () => {
+    // provider minzoom=3, maxzoom=5. Before the fix, getTilesForBBox started
+    // at z=0 regardless of minzoom, so totalTiles would include the three
+    // low-zoom tiles we'd never actually seed. With the fix in place we
+    // should only see tiles from the provider's declared zoom range.
+    await plugin.start({ onlineChartProviders: [proxyProvider] })
+    const maxZoom = '5'
+    const bbox = { minLon: 5, minLat: 5, maxLon: 6, maxLat: 6 }
+    const withMinzoom = await chai
+      .request(`http://localhost:${serverPort(testServer)}`)
+      .post('/signalk/chart-tiles/cache/proxy-test')
+      .send({ maxZoom, bbox })
+    expect(withMinzoom.status).to.equal(202)
+    // With minzoom=3 we cover z=3..5, which for a tiny bbox well within a
+    // tile at each zoom is 3 tiles total. If minzoom were ignored we'd see
+    // 6 (also z=0,1,2 would each contribute 1 tile).
+    expect(withMinzoom.body.totalTiles).to.equal(3)
+  })
+
+  it('POST /cache/jobs/:id returns 400 on a non-numeric job id', async () => {
+    await plugin.start({ onlineChartProviders: [proxyProvider] })
+    const res = await chai
+      .request(`http://localhost:${serverPort(testServer)}`)
+      .post('/signalk/chart-tiles/cache/jobs/not-a-number')
+      .send({ action: 'start' })
+      .catch(e => e.response)
+    expect(res.status).to.equal(400)
+  })
+
+  it('POST /cache/jobs/:id returns 404 for an unknown job', async () => {
+    await plugin.start({ onlineChartProviders: [proxyProvider] })
+    const res = await chai
+      .request(`http://localhost:${serverPort(testServer)}`)
+      .post('/signalk/chart-tiles/cache/jobs/99999')
+      .send({ action: 'start' })
+      .catch(e => e.response)
+    expect(res.status).to.equal(404)
+  })
+
+  it('POST /cache/jobs/:id returns 400 for a missing action', async () => {
+    await plugin.start({ onlineChartProviders: [proxyProvider] })
+    const createRes = await chai
+      .request(`http://localhost:${serverPort(testServer)}`)
+      .post('/signalk/chart-tiles/cache/proxy-test')
+      .send({ maxZoom: '4', bbox: { minLon: 0, minLat: 0, maxLon: 1, maxLat: 1 } })
+    expect(createRes.status).to.equal(202)
+    const jobId = createRes.body.id
+
+    const res = await chai
+      .request(`http://localhost:${serverPort(testServer)}`)
+      .post(`/signalk/chart-tiles/cache/jobs/${jobId}`)
+      .send({})
+      .catch(e => e.response)
+    expect(res.status).to.equal(400)
+  })
+
+  it('POST /cache/jobs/:id returns 400 for an unknown action', async () => {
+    await plugin.start({ onlineChartProviders: [proxyProvider] })
+    const createRes = await chai
+      .request(`http://localhost:${serverPort(testServer)}`)
+      .post('/signalk/chart-tiles/cache/proxy-test')
+      .send({ maxZoom: '4', bbox: { minLon: 0, minLat: 0, maxLon: 1, maxLat: 1 } })
+    const jobId = createRes.body.id
+
+    const res = await chai
+      .request(`http://localhost:${serverPort(testServer)}`)
+      .post(`/signalk/chart-tiles/cache/jobs/${jobId}`)
+      .send({ action: 'detonate' })
+      .catch(e => e.response)
+    expect(res.status).to.equal(400)
+  })
+})
+
 
 const expectTileResponse = (response: ChaiHttp.Response, expectedTilePath: string, expectedFormat: string) => {
   const expectedTile = fs.readFileSync(path.resolve(__dirname, expectedTilePath))
@@ -355,4 +496,12 @@ const get = (server: http.Server, location: string) => {
   return chai
     .request(baseUrl)
     .get(location)
+}
+
+const serverPort = (server: http.Server): number => {
+  const address = server.address()
+  if (!address || typeof address === 'string') {
+    throw new Error('Test server has no address')
+  }
+  return address.port
 }

--- a/test/projection-test.ts
+++ b/test/projection-test.ts
@@ -1,15 +1,15 @@
-'use strict'
-const chai = require('chai')
-const expect = chai.expect
-const {
+import chai from 'chai'
+import {
   WEB_MERCATOR_HALF_EXTENT_M,
+  WEB_MERCATOR_MAX_LAT,
   tileToBBox,
-  lonLatToMercator
-} = require('../plugin/projection')
+  lonLatToMercator,
+  lonLatToTile
+} from '../src/projection'
 
-const WEB_MERCATOR_MAX_LAT = 85.0511287798066
+const expect = chai.expect
 
-const approx = (actual, expected, tolerance = 1e-6) => {
+const approx = (actual: number, expected: number, tolerance = 1e-6) => {
   expect(
     Math.abs(actual - expected),
     `${actual} not within ${tolerance} of ${expected}`
@@ -92,5 +92,45 @@ describe('projection: lonLatToMercator', () => {
     const [x1] = lonLatToMercator(45, 10)
     const [x2] = lonLatToMercator(90, 10)
     approx(x2, x1 * 2, 1e-6)
+  })
+})
+
+describe('projection: lonLatToTile', () => {
+  it('maps the world origin to (0,0) at z=0', () => {
+    const [x, y] = lonLatToTile(0, 0, 0)
+    expect(x).to.equal(0)
+    expect(y).to.equal(0)
+  })
+
+  it('splits the equator at z=1 into x=0 (west) and x=1 (east)', () => {
+    const [west] = lonLatToTile(-90, 0, 1)
+    const [east] = lonLatToTile(90, 0, 1)
+    expect(west).to.equal(0)
+    expect(east).to.equal(1)
+  })
+
+  it('returns integer tile coords', () => {
+    const [x, y] = lonLatToTile(13.4, 52.5, 8)
+    expect(Number.isInteger(x)).to.equal(true)
+    expect(Number.isInteger(y)).to.equal(true)
+  })
+
+  it('clamps latitudes at or beyond the poles instead of returning NaN', () => {
+    // Without clamping, tan(π/2) blows up and the floor of NaN is NaN.
+    // A user dragging a selection that touches ±90 shouldn't poison the tile set.
+    const [xNorth, yNorth] = lonLatToTile(0, 90, 4)
+    expect(Number.isFinite(xNorth)).to.equal(true)
+    expect(Number.isFinite(yNorth)).to.equal(true)
+    expect(yNorth).to.be.within(0, 2 ** 4 - 1)
+
+    const [xSouth, ySouth] = lonLatToTile(0, -90, 4)
+    expect(Number.isFinite(xSouth)).to.equal(true)
+    expect(Number.isFinite(ySouth)).to.equal(true)
+    expect(ySouth).to.be.within(0, 2 ** 4 - 1)
+  })
+
+  it('clamps at WEB_MERCATOR_MAX_LAT (north tile = 0)', () => {
+    const [, y] = lonLatToTile(0, WEB_MERCATOR_MAX_LAT, 5)
+    expect(y).to.equal(0)
   })
 })


### PR DESCRIPTION
Addresses bugs and hot-path costs surfaced by a pre-release review of the tile-serving, tile-caching/seeding, reload, and chart-discovery paths.

## Release blockers (tile-caching API)

- `ChartSeedingManager.createJob` now awaits the init call. Previously the POST handler returned before the job knew its tile set; callers who followed up with an immediate \"start\" raced the init reads.
- `POST /cache/:identifier` returns `202` with the fully-initialised job info (id, totalTiles, status) instead of a fake `COMPLETED` response before any tile has been downloaded.
- `POST /cache/:identifier` returns `404` (not `500`) with a single response on an unknown provider; the prior `sendStatus().send()` chain crashed the response path.
- `POST /cache/jobs/:id` returns `400` / `404` on unknown id, non-numeric id, missing action, and unknown action instead of hanging the client.
- Resource provider is registered once per plugin lifetime; a restart no longer re-registers (silent double-registration or swallowed throw). Registration failures surface via `setPluginError`.

## Seeding correctness and cost

- `filterCachedTiles` runs once per seed start, not twice. Also bounded by `p-limit(64)` so a 100k-tile bbox doesn't fire 100k concurrent `fs.access` calls and trip EMFILE.
- `seedCache` refuses to start a second time while Running; post-await checks `cancelRequested` so in-flight fetches don't keep mutating counters after cancellation.
- `lonLatToTile` clamps lat to Web Mercator bounds so a bbox touching ±90 can't produce NaN tile coordinates. Moved to `projection.ts` and shared with the other mercator helpers.
- `getTilesForBBox` starts at `provider.minzoom` instead of `z=0`, so low zooms outside the provider's declared range don't inflate `totalTiles`.
- `plugin.stop()` calls `ChartSeedingManager.cancelAll()` so a disabled plugin doesn't keep pulling tiles in the background.
- `getTilesForGeoJSON` adds a cheap AABB pre-filter before the expensive turf `booleanIntersects` call.

## Reload / metadata hot path

- `loadChartProviders` runs per-chart-path scans in parallel and replaces the O(N²) `_.reduce`/`_.merge` dict build with a single-pass shallow assign. Identifier collisions are now logged.
- `findCharts` scans under a `pLimit(12)` global limiter so a fleet of 500 MBTiles files opens concurrently instead of serially. Directory recursion stays outside the limiter to avoid deadlock.
- The v1 route handlers and the v2 resource-provider methods serve a pre-built sanitized view keyed by identifier, rebuilt once per reload. Previously every metadata request deep-cloned every provider three times via lodash.
- `sanitizeProvider` is a single shallow walk over the provider's fields instead of three lodash clones.

## Reload handle reconciliation

- After a reload, every pre-existing MBTiles handle is closed (with a small delay so in-flight tile requests that captured a reference can complete). Previously we tried to reuse handles when `_filePath` was unchanged, but that served stale content when a file was replaced in place.

## Other

- `serveTileFromMbtiles` guards against a missing `_mbtilesHandle` instead of throwing synchronously.
- `ensureDirectoryExists` is async (`fs.promises.mkdir({recursive:true})`), called from `doStartup` instead of at module load.
- Projection test file renamed to `.ts` so it is actually picked up by the mocha runner.

## Tests

- 5 projection tests covering `lonLatToTile`, including the pole clamp.
- 8 HTTP tests covering the new cache-endpoint response codes and the minzoom respect in bbox seeding.
- All 42 tests pass; lint and prettier clean.