### PR TITLE
refactor: swap xml2js for fast-xml-parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,10 +15,10 @@
         "@turf/boolean-intersects": "^7.2.0",
         "@turf/helpers": "^7.2.0",
         "check-disk-space": "^3.4.0",
+        "fast-xml-parser": "^5.7.1",
         "geojson-antimeridian-cut": "^0.1.0",
         "lodash": "^4.17.11",
-        "p-limit": "^3",
-        "xml2js": "0.6.2"
+        "p-limit": "^3"
       },
       "devDependencies": {
         "@stryker-mutator/core": "^9.6.1",
@@ -1516,6 +1516,18 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.3.1",
@@ -3123,6 +3135,42 @@
         "fast-string-width": "^3.0.2"
       }
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
+      "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/figures": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
@@ -4345,6 +4393,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -4685,15 +4748,6 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/sax": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
-      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=11.0.0"
-      }
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -5044,6 +5098,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/superagent": {
       "version": "8.1.2",
@@ -5533,28 +5599,6 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/xml2js": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
-      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
-      "license": "MIT",
-      "dependencies": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/xmlbuilder": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -39,10 +39,10 @@
     "@turf/boolean-intersects": "^7.2.0",
     "@turf/helpers": "^7.2.0",
     "check-disk-space": "^3.4.0",
+    "fast-xml-parser": "^5.7.1",
     "geojson-antimeridian-cut": "^0.1.0",
     "lodash": "^4.17.11",
-    "p-limit": "^3",
-    "xml2js": "0.6.2"
+    "p-limit": "^3"
   },
   "repository": {
     "type": "git",

--- a/src/charts.ts
+++ b/src/charts.ts
@@ -1,9 +1,35 @@
 import path from 'path'
-import * as xml2js from 'xml2js'
+import { XMLParser } from 'fast-xml-parser'
 import { Dirent, promises as fs } from 'fs'
 import pLimit from 'p-limit'
 import { ChartProvider } from './types'
-import { promisify } from 'util'
+
+// Parses tilemapresource.xml into a plain object. ignoreAttributes=false and
+// attributeNamePrefix='' drop the default '@_' prefix so XML attributes show
+// up as normal keys. isArray forces TileSet to always be an array even when
+// the XML contains only one, so the zoom-level extraction below doesn't have
+// to special-case the single-element shape.
+// Input  (simplified): <TileMap><Title>Foo</Title>
+//                        <TileFormat extension="png"/>
+//                        <BoundingBox minx="0" miny="0" maxx="1" maxy="1"/>
+//                        <TileSets><TileSet href="4"/><TileSet href="5"/></TileSets>
+//                      </TileMap>
+// Parsed: { TileMap: {
+//            Title: 'Foo',
+//            TileFormat: { extension: 'png' },
+//            BoundingBox: { minx: '0', miny: '0', maxx: '1', maxy: '1' },
+//            TileSets: { TileSet: [ { href: '4' }, { href: '5' } ] }
+//          } }
+const xmlParser = new XMLParser({
+  ignoreAttributes: false,
+  attributeNamePrefix: '',
+  isArray: (name) => name === 'TileSet',
+  // Keep tag text as strings (e.g. "1234" stays "1234", not 1234) so
+  // ChartProvider fields like name/format/scale have stable types regardless
+  // of content.
+  parseTagValue: false,
+  parseAttributeValue: false
+})
 
 // Dynamically load MBTiles to prevent module load failure
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -221,45 +247,38 @@ function directoryToMapInfo(file: string, identifier: string) {
 }
 
 function parseTilemapResource(tilemapResource: string) {
-  const parseString = promisify(xml2js.parseString)
-  return (
-    fs
-      .readFile(tilemapResource)
-      .then((data) => parseString(data))
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      .then((parsed: any) => {
-        const result = parsed.TileMap
-        const name = result?.Title?.[0]
-        const format = result?.TileFormat?.[0]?.$?.extension
-        const scale = result?.Metadata?.[0]?.$?.scale
-        const bbox = result?.BoundingBox?.[0]?.$
-        const zoomLevels: number[] = (result?.TileSets?.[0]?.TileSet || []).map(
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (set: any) => parseInt(set?.$?.href)
-        )
-        const res: ChartProvider = {
-          _flipY: true,
-          name,
-          description: name,
-          bounds: bbox
-            ? [
-                parseFloat(bbox.minx),
-                parseFloat(bbox.miny),
-                parseFloat(bbox.maxx),
-                parseFloat(bbox.maxy)
-              ]
-            : undefined,
-          minzoom: zoomLevels.length ? Math.min(...zoomLevels) : undefined,
-          maxzoom: zoomLevels.length ? Math.max(...zoomLevels) : undefined,
-          format,
-          type: 'tilelayer',
-          scale: parseInt(scale) || 250000,
-          identifier: '',
-          _filePath: ''
-        }
-        return res
-      })
-  )
+  return fs.readFile(tilemapResource, 'utf8').then((data) => {
+    const parsed = xmlParser.parse(data)
+    const result = parsed.TileMap
+    const name = result?.Title
+    const format = result?.TileFormat?.extension
+    const scale = result?.Metadata?.scale
+    const bbox = result?.BoundingBox
+    const zoomLevels: number[] = (result?.TileSets?.TileSet || []).map(
+      (set: { href?: string }) => parseInt(set?.href ?? '')
+    )
+    const res: ChartProvider = {
+      _flipY: true,
+      name,
+      description: name,
+      bounds: bbox
+        ? [
+            parseFloat(bbox.minx),
+            parseFloat(bbox.miny),
+            parseFloat(bbox.maxx),
+            parseFloat(bbox.maxy)
+          ]
+        : undefined,
+      minzoom: zoomLevels.length ? Math.min(...zoomLevels) : undefined,
+      maxzoom: zoomLevels.length ? Math.max(...zoomLevels) : undefined,
+      format,
+      type: 'tilelayer',
+      scale: parseInt(scale) || 250000,
+      identifier: '',
+      _filePath: ''
+    }
+    return res
+  })
 }
 
 function parseMetadataJson(metadataJson: string) {


### PR DESCRIPTION
## Summary
- Replaces `xml2js 0.6.2` (unmaintained, no release since 2022) with `fast-xml-parser ^5.7.1` (actively maintained, smaller, ships its own types).
- `parseTilemapResource` in [src/charts.ts](src/charts.ts) now uses the synchronous `XMLParser.parse`, dropping the `promisify` wrapper and the `\$`-keyed attribute traversal.

### Parser config notes
- `attributeNamePrefix: ''` so attribute names become normal keys (replacing `obj.$.name` with `obj.name`).
- `isArray: (name) => name === 'TileSet'` so a single `<TileSet>` is still wrapped as an array. This matches xml2js' "children are always arrays" default for the one spot that cares.
- `parseTagValue: false` and `parseAttributeValue: false` so numeric-looking text stays as strings, preserving the downstream field types on `ChartProvider`.

## Test plan
- [x] `npm run ci-lint` clean
- [x] `npm test` — 17/17 pass (full round-trip through `tms-tiles/tilemapresource.xml` asserting name, format, scale, bounds, minzoom/maxzoom against `expected-charts.json`)