### PR TITLE
feat: show per-path chart counts in plugin status banner (fixes #8)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import fs, { FSWatcher } from 'fs'
 import * as _ from 'lodash'
 import { findCharts } from './charts'
 import { apiRoutePrefix } from './constants'
+import { composeStatus, ChartPathCount } from './pluginStatus'
 import { ChartProvider, MBTilesHandle, OnlineChartProvider } from './types'
 import { ChartSeedingManager, Tile } from './chartDownloader'
 import {
@@ -330,9 +331,13 @@ const createPlugin = (app: ChartProviderApp): Plugin => {
     // O(N²) property copies for identical keys while adding nothing over a
     // plain shallow assignment.
     const newCharts: { [key: string]: ChartProvider } = {}
-    for (const r of results) {
-      if (!r) continue
-      for (const [id, chart] of Object.entries(r)) {
+    const perPath: ChartPathCount[] = []
+    for (let i = 0; i < results.length; i++) {
+      const r = results[i]
+      const chartPath = activeChartPaths[i] ?? ''
+      const pathEntries = r ? Object.entries(r) : []
+      perPath.push({ chartPath, count: pathEntries.length })
+      for (const [id, chart] of pathEntries) {
         if (newCharts[id]) {
           app.debug(
             `Duplicate chart identifier "${id}" from multiple chart paths; ` +
@@ -363,7 +368,7 @@ const createPlugin = (app: ChartProviderApp): Plugin => {
     }
     buildSanitizedCache()
     app.setPluginStatus(
-      `Started - ${Object.keys(chartProviders).length} chart(s) loaded`
+      composeStatus(perPath, Object.keys(activeOnlineProviders).length)
     )
   }
 

--- a/src/pluginStatus.ts
+++ b/src/pluginStatus.ts
@@ -1,0 +1,49 @@
+// Builds the human-readable message shown in the admin UI plugin status banner
+// after startup. Motivation: issue #8 - users who add a new chart path want to
+// see per-path feedback ("Found 0 charts from /foo") so they can tell whether
+// their path resolved and picked anything up.
+
+export interface ChartPathCount {
+  chartPath: string
+  count: number
+}
+
+// Examples:
+//   composeStatus([{chartPath: '/a', count: 5}], 0)
+//     -> "Started - Found 5 charts from /a"
+//   composeStatus([{chartPath: '/a', count: 0}], 2)
+//     -> "Started - Found 0 charts from /a + 2 online providers"
+//   composeStatus([{chartPath: '/a', count: 2}, {chartPath: '/b', count: 3}], 0)
+//     -> "Started - Found 5 charts: /a (2), /b (3)"
+export function composeStatus(
+  perPath: ChartPathCount[],
+  onlineProviderCount: number
+): string {
+  const totalCharts = perPath.reduce((sum, p) => sum + p.count, 0)
+  let chartsPart: string
+  if (perPath.length === 0) {
+    chartsPart = `Found ${totalCharts} ${plural('chart', totalCharts)}`
+  } else if (perPath.length === 1) {
+    chartsPart = `Found ${totalCharts} ${plural('chart', totalCharts)} from ${
+      perPath[0]!.chartPath
+    }`
+  } else {
+    const breakdown = perPath
+      .map((p) => `${p.chartPath} (${p.count})`)
+      .join(', ')
+    chartsPart = `Found ${totalCharts} ${plural(
+      'chart',
+      totalCharts
+    )}: ${breakdown}`
+  }
+  const onlinePart =
+    onlineProviderCount > 0
+      ? ` + ${onlineProviderCount} online ${plural(
+          'provider',
+          onlineProviderCount
+        )}`
+      : ''
+  return `Started - ${chartsPart}${onlinePart}`
+}
+
+const plural = (word: string, n: number) => (n === 1 ? word : `${word}s`)

--- a/test/plugin-test.ts
+++ b/test/plugin-test.ts
@@ -54,11 +54,13 @@ const TMP_BASE = path.resolve(__dirname, '.tmp')
 describe('GET /resources/charts', () => {
   let plugin: PluginInstance
   let testServer: http.Server
+  let testApp: TestApp
 
   beforeEach(() =>
     createDefaultApp().then(({ app, server }) => {
       plugin = asPluginApp(app)
       testServer = server
+      testApp = app
     })
   )
   afterEach((done) => {
@@ -170,6 +172,48 @@ describe('GET /resources/charts', () => {
       .catch((e) => e.response)
       .then((result) => {
         expect(result.status).to.equal(404)
+      })
+  })
+  it('publishes per-path chart counts in the plugin status banner (issue #8)', () => {
+    return plugin.start({ chartPaths: ['charts', 'charts-2'] }).then(() => {
+      expect(testApp.lastPluginStatus).to.equal(
+        `Started - Found 4 charts: ${path.resolve(
+          __dirname,
+          'charts'
+        )} (3), ${path.resolve(__dirname, 'charts-2')} (1)`
+      )
+    })
+  })
+
+  it('reports 0 charts from the configured path when the path is empty (issue #8)', () => {
+    return plugin.start({ chartPaths: ['../src/'] }).then(() => {
+      expect(testApp.lastPluginStatus).to.equal(
+        `Started - Found 0 charts from ${path.resolve(__dirname, '../src')}`
+      )
+    })
+  })
+
+  it('includes online provider count in the status banner', () => {
+    return plugin
+      .start({
+        chartPaths: ['charts'],
+        onlineChartProviders: [
+          {
+            name: 'Test Name',
+            minzoom: 2,
+            maxzoom: 15,
+            format: 'jpg',
+            url: 'https://example.com'
+          }
+        ]
+      })
+      .then(() => {
+        expect(testApp.lastPluginStatus).to.equal(
+          `Started - Found 3 charts from ${path.resolve(
+            __dirname,
+            'charts'
+          )} + 1 online provider`
+        )
       })
   })
 })
@@ -663,6 +707,7 @@ interface TestApp extends express.Express {
   statusMessage: () => string
   setPluginStatus: (pluginId: string, status: string) => void
   setPluginError: (pluginId: string, status: string) => void
+  lastPluginStatus?: string
 }
 
 const createDefaultApp = (): Promise<{ app: TestApp; server: http.Server }> => {
@@ -672,7 +717,11 @@ const createDefaultApp = (): Promise<{ app: TestApp; server: http.Server }> => {
   app.statusMessage = () => 'started'
   app.error = () => undefined
   app.debug = () => undefined
-  app.setPluginStatus = () => undefined
+  // Single-arg signature matches what the plugin actually calls at runtime;
+  // the ServerAPI type is (id, status) but Signal K server binds the id.
+  app.setPluginStatus = ((status: string) => {
+    app.lastPluginStatus = status
+  }) as unknown as TestApp['setPluginStatus']
   app.setPluginError = () => undefined
 
   return new Promise((resolve) => {

--- a/test/pluginStatus-test.ts
+++ b/test/pluginStatus-test.ts
@@ -1,0 +1,76 @@
+import chai from 'chai'
+import { composeStatus } from '../src/pluginStatus'
+
+const expect = chai.expect
+
+describe('composeStatus', () => {
+  it('handles a single path with charts', () => {
+    expect(
+      composeStatus([{ chartPath: '/home/user/.signalk/charts', count: 5 }], 0)
+    ).to.equal('Started - Found 5 charts from /home/user/.signalk/charts')
+  })
+
+  it('addresses issue #8: reports 0 charts found from the configured path', () => {
+    expect(
+      composeStatus([{ chartPath: '/home/jduno/.signalk/charts', count: 0 }], 0)
+    ).to.equal('Started - Found 0 charts from /home/jduno/.signalk/charts')
+  })
+
+  it('uses singular form when exactly one chart is found', () => {
+    expect(composeStatus([{ chartPath: '/a', count: 1 }], 0)).to.equal(
+      'Started - Found 1 chart from /a'
+    )
+  })
+
+  it('lists per-path counts when multiple paths are configured', () => {
+    expect(
+      composeStatus(
+        [
+          { chartPath: '/a', count: 2 },
+          { chartPath: '/b', count: 3 }
+        ],
+        0
+      )
+    ).to.equal('Started - Found 5 charts: /a (2), /b (3)')
+  })
+
+  it('includes online provider count when present', () => {
+    expect(composeStatus([{ chartPath: '/a', count: 4 }], 2)).to.equal(
+      'Started - Found 4 charts from /a + 2 online providers'
+    )
+  })
+
+  it('uses singular "provider" for a single online provider', () => {
+    expect(composeStatus([{ chartPath: '/a', count: 4 }], 1)).to.equal(
+      'Started - Found 4 charts from /a + 1 online provider'
+    )
+  })
+
+  it('omits online part when no online providers are configured', () => {
+    expect(composeStatus([{ chartPath: '/a', count: 4 }], 0)).to.equal(
+      'Started - Found 4 charts from /a'
+    )
+  })
+
+  it('handles the empty case with no paths and no online providers', () => {
+    expect(composeStatus([], 0)).to.equal('Started - Found 0 charts')
+  })
+
+  it('handles no paths but some online providers', () => {
+    expect(composeStatus([], 3)).to.equal(
+      'Started - Found 0 charts + 3 online providers'
+    )
+  })
+
+  it('preserves path order in the breakdown', () => {
+    expect(
+      composeStatus(
+        [
+          { chartPath: '/zzz', count: 1 },
+          { chartPath: '/aaa', count: 1 }
+        ],
+        0
+      )
+    ).to.equal('Started - Found 2 charts: /zzz (1), /aaa (1)')
+  })
+})


### PR DESCRIPTION
## Summary
- Plugin status now reports per chart path, including the path itself and the number of charts found, so users who mistype a path or point at the wrong folder get immediate feedback on the admin dashboard.
- Uses proper pluralization and appends an online-provider count if any are configured.

Examples:
- `Started - Found 5 charts from /home/user/.signalk/charts`
- `Started - Found 0 charts from /home/user/.signalk/charts` (empty path, as requested in the issue)
- `Started - Found 4 charts: /a (3), /b (1)` (multiple paths)
- `Started - Found 3 charts from /a + 1 online provider`

Fixes #8.

## Screenshots
Taken against a Signal K server in Docker with the plugin mounted from this branch; the text is set via `setPluginStatus` and appears in the admin dashboard's **Connection & Plugin Status** table.

Single path (default):
`Started - Found 2 charts from /home/node/.signalk/charts`

Two paths configured (`charts`, `extra-charts`):
`Started - Found 3 charts: /home/node/.signalk/charts (2), /home/node/.signalk/extra-charts (1)`
(Note: the admin UI truncates long status strings in the dashboard column - PR 2, which surfaces per-path counts in the config form descriptions, complements this.)

## Test plan
- [x] `npm run ci-lint` clean
- [x] `npm test` - 55 passing (10 new unit tests for the formatter + 3 new integration tests that capture `setPluginStatus` calls)
- [x] Verified in Docker SK server with single path (default) and two configured paths