### PR TITLE
feat: show per-path chart counts in plugin config description (fixes #8)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -79,13 +79,31 @@ const createPlugin = (app: ChartProviderApp): Plugin => {
   let reloadTimer: NodeJS.Timeout | undefined
   let activeChartPaths: string[] = []
   let activeOnlineProviders: { [key: string]: object } = {}
+  // Last scan result, surfaced in the config schema description so the admin
+  // UI shows per-path counts when the user reopens the plugin config. Issue #8.
+  let lastChartPathCounts: ChartPathCount[] = []
 
   // Check Node version for schema
   const nodeVersion = process.versions.node
   const nodeMajorVersion = parseInt(nodeVersion.split('.')[0] ?? '0')
 
+  // Builds the `chartPaths` description, appending the latest per-path chart
+  // counts when available. The admin UI re-fetches the schema every time the
+  // plugin config page opens, so this text refreshes on reload. Issue #8.
+  const chartPathsDescription = () => {
+    const base = `Add one or more paths to find charts. Defaults to "${defaultChartsPath}"`
+    if (lastChartPathCounts.length === 0) return base
+    const parts = lastChartPathCounts.map(
+      (p) => `${p.chartPath} (${p.count} ${p.count === 1 ? 'chart' : 'charts'})`
+    )
+    return `${base}. Last scan: ${parts.join(', ')}.`
+  }
+
   // ******** REQUIRED PLUGIN DEFINITION *******
-  const CONFIG_SCHEMA = {
+  // Schema is built inside schema() rather than a module-level const, because
+  // chartPaths.description depends on the last scan result, which only exists
+  // after the plugin has run at least once.
+  const buildConfigSchema = () => ({
     title: 'Signal K Charts',
     type: 'object',
     properties: {
@@ -101,7 +119,7 @@ const createPlugin = (app: ChartProviderApp): Plugin => {
       chartPaths: {
         type: 'array',
         title: 'Chart paths',
-        description: `Add one or more paths to find charts. Defaults to "${defaultChartsPath}"`,
+        description: chartPathsDescription(),
         items: {
           type: 'string',
           title: 'Path',
@@ -212,14 +230,14 @@ const createPlugin = (app: ChartProviderApp): Plugin => {
         }
       }
     }
-  }
+  })
 
   const CONFIG_UISCHEMA = {}
 
   const plugin: Plugin = {
     id: 'charts',
     name: 'Signal K Charts',
-    schema: () => CONFIG_SCHEMA,
+    schema: () => buildConfigSchema(),
     uiSchema: () => CONFIG_UISCHEMA,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     start: (settings: any) => {
@@ -347,6 +365,7 @@ const createPlugin = (app: ChartProviderApp): Plugin => {
         newCharts[id] = chart
       }
     }
+    lastChartPathCounts = perPath
     app.debug(
       `Chart plugin: Found ${
         Object.keys(newCharts).length

--- a/test/plugin-test.ts
+++ b/test/plugin-test.ts
@@ -31,6 +31,7 @@ const expect = chai.expect
 type PluginInstance = {
   start: (settings: object) => Promise<void>
   stop: () => void
+  schema?: () => unknown
 }
 
 // TestApp intentionally omits most of ServerAPI since these are
@@ -215,6 +216,32 @@ describe('GET /resources/charts', () => {
           )} + 1 online provider`
         )
       })
+  })
+
+  it('config schema chartPaths description omits scan info before first start (issue #8)', () => {
+    const schema = getChartPathsSchema(plugin)
+    expect(schema.description).to.match(
+      /^Add one or more paths to find charts\. Defaults to/
+    )
+    expect(schema.description).to.not.include('Last scan')
+  })
+
+  it('config schema chartPaths description shows per-path counts after load (issue #8)', () => {
+    return plugin.start({ chartPaths: ['charts', 'charts-2'] }).then(() => {
+      const schema = getChartPathsSchema(plugin)
+      expect(schema.description).to.include(
+        `Last scan: ${path.resolve(__dirname, 'charts')} (3 charts), ${path.resolve(__dirname, 'charts-2')} (1 chart)`
+      )
+    })
+  })
+
+  it('config schema chartPaths description reports zero charts when path is empty (issue #8)', () => {
+    return plugin.start({ chartPaths: ['../src/'] }).then(() => {
+      const schema = getChartPathsSchema(plugin)
+      expect(schema.description).to.include(
+        `Last scan: ${path.resolve(__dirname, '../src')} (0 charts)`
+      )
+    })
   })
 })
 
@@ -744,6 +771,18 @@ const get = (server: http.Server, location: string) => {
   }
   const baseUrl = `http://localhost:${address.port}`
   return chai.request.execute(baseUrl).get(location)
+}
+
+const getChartPathsSchema = (plugin: PluginInstance) => {
+  const schema = plugin.schema?.() as {
+    properties: {
+      chartPaths: { description: string }
+    }
+  }
+  if (!schema?.properties?.chartPaths) {
+    throw new Error('schema() did not return chartPaths')
+  }
+  return schema.properties.chartPaths
 }
 
 const serverPort = (server: http.Server): number => {


### PR DESCRIPTION
## Summary
The admin UI re-fetches the plugin schema every time the config page opens, so appending the latest per-path chart counts to the `chartPaths` description surfaces immediate feedback right next to the path inputs. The hint refreshes on every reopen of the config.

Before:
> Add one or more paths to find charts. Defaults to "/home/user/.signalk/charts"

After:
> Add one or more paths to find charts. Defaults to "/home/user/.signalk/charts". Last scan: /home/user/.signalk/charts (2 charts), /home/user/extra (1 chart).

This is complementary to #79, which surfaces the same information in the plugin status banner on the admin dashboard. Either PR on its own addresses the spirit of the issue; together they give the user feedback both on the dashboard and in the config form.

Fixes #8.

## Screenshots
Taken against a Signal K server in Docker with the plugin mounted from this branch; user has added `extra-charts` as a second chart path.

The "Chart paths" description now ends with:
`Last scan: /home/node/.signalk/charts (2 charts), /home/node/.signalk/extra-charts (1 chart).`

## Test plan
- [x] `npm run ci-lint` clean
- [x] `npm test` - 45 passing (3 new integration tests that exercise `schema()` before/after start and assert on the description)
- [x] Manually verified in Docker SK server that reopening the plugin config page refreshes the hint after chart files change