### PR TITLE
chore: switch moduleResolution to bundler, drop ignoreDeprecations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@signalk/charts-plugin",
-  "version": "3.4.0",
+  "version": "3.5.0-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@signalk/charts-plugin",
-      "version": "3.4.0",
+      "version": "3.5.0-beta",
       "license": "Apache-2.0",
       "dependencies": {
         "@signalk/mbtiles": "0.1.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,12 +2,7 @@
   "compilerOptions": {
     "target": "ES2022",
     "module": "commonjs",
-    "moduleResolution": "node",
-    // TS 6.0 deprecated the legacy "node" (a.k.a. node10) moduleResolution
-    // and makes it a hard error. Silence that here so this CommonJS plugin
-    // can stay on `node` resolution for now; migrating to "node16" / "bundler"
-    // is a separate change that needs the import paths audited.
-    "ignoreDeprecations": "6.0",
+    "moduleResolution": "bundler",
     "lib": ["ES2022"],
 
     "strict": true,
@@ -17,8 +12,6 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noUncheckedIndexedAccess": true,
-    // Each file must transpile independently (tsx / esbuild / bundler
-    // assumptions). Surfaces edge cases before they break a downstream.
     "isolatedModules": true,
 
     "esModuleInterop": true,
@@ -26,8 +19,6 @@
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,
-    // TS 6 made default @types scan stricter: mocha's `describe`/`it` globals
-    // no longer leak in unless the test runner is listed here explicitly.
     "types": ["node", "mocha"],
 
     "declaration": true,


### PR DESCRIPTION
## Summary

TS 6 made the legacy `node` moduleResolution a hard deprecation. Switch to `bundler` instead of silencing with `ignoreDeprecations`:

- Matches runtime (tsx / esbuild / plain node) behaviour.
- Drops the `ignoreDeprecations` escape hatch.
- Keeps `module: commonjs` so the shipped output stays CJS (required by signalk-server).

Also strips explanatory comments from tsconfig.

## Test plan

- [x] npm run typecheck clean
- [x] npm run build clean
- [x] npm test 42 passing
- [ ] CI green on Node 22 + Node 24