### PR TITLE
Harden tile endpoints and split tile serving

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -1,193 +1,231 @@
-;(function () {})()
-
-document.addEventListener('DOMContentLoaded', async () => {
-  const regionSelect = document.getElementById('region')
-  const bboxInputs = document.querySelectorAll(
-    '#bboxMinLon, #bboxMinLat, #bboxMaxLon, #bboxMaxLat'
-  )
-  const tileInputs = document.querySelectorAll('#tileX, #tileY, #tileZ')
-
-  function updateInputs() {
-    const type = document.querySelector('input[name="inputType"]:checked').value
-
-    regionSelect.disabled = type !== 'region'
-    bboxInputs.forEach((i) => (i.disabled = type !== 'bbox'))
-    tileInputs.forEach((i) => (i.disabled = type !== 'tile'))
-  }
-
-  // Attach listeners
-  document.querySelectorAll('input[name="inputType"]').forEach((r) => {
-    r.addEventListener('change', updateInputs)
-  })
-
-  updateInputs() // initial load
-
-  if (!regionSelect) return
-
-  try {
-    const resp = await fetch('/signalk/v2/api/resources/regions')
-    if (!resp.ok) throw new Error(`Failed to fetch regions: ${resp.status}`)
-    const data = await resp.json()
-    // clear existing options
-    regionSelect.innerHTML = ''
-
-    const entries = Object.entries(data || {})
-    entries
-      .sort(([, a], [, b]) => {
-        const na = a && a.name ? String(a.name) : ''
-        const nb = b && b.name ? String(b.name) : ''
-        return na.localeCompare(nb)
-      })
-      .forEach(([id, info]) => {
-        const opt = document.createElement('option')
-        opt.value = id
-        opt.textContent = info && info.name ? info.name : id
-        regionSelect.appendChild(opt)
-      })
-
-    // if no regions returned, add a fallback option
-    if (!regionSelect.options.length) {
-      const opt = document.createElement('option')
-      opt.value = ''
-      opt.textContent = '-- No regions available --'
-      regionSelect.appendChild(opt)
+// POSTs a seed-job request and returns the parsed job info. Extracted so the
+// fetch + response-validation logic can be unit-tested in node without jsdom.
+// The browser still calls this from the click handler below.
+async function submitSeedJob(chart, body, fetchImpl) {
+  const fetchFn = fetchImpl || globalThis.fetch
+  const resp = await fetchFn(
+    `/signalk/chart-tiles/cache/${encodeURIComponent(chart)}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body)
     }
-  } catch (err) {
-    console.error('Error loading regions:', err)
+  )
+  if (!resp.ok) {
+    let text = ''
+    try {
+      text = await resp.text()
+    } catch (_readErr) {
+      // Ignore read errors when composing the error message; the status code
+      // and our surrounding context are enough to diagnose.
+    }
+    throw new Error(
+      `Failed to seed charts: ${resp.status}${text ? ` - ${text}` : ''}`
+    )
   }
+  const data = await resp.json()
+  if (!data || typeof data.id !== 'number') {
+    throw new Error('Job response is missing a numeric id')
+  }
+  return data
+}
 
-  //Fetch available maps and populate the chart select box
-  const chartSelect = document.getElementById('chart')
-  if (!chartSelect) return
+// Node-only export for the unit test. The browser script tag ignores this
+// branch because `module` is undefined in a plain <script>.
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { submitSeedJob }
+}
 
-  try {
-    const resp = await fetch('/signalk/v2/api/resources/charts')
-    if (!resp.ok) throw new Error(`Failed to fetch charts: ${resp.status}`)
-    const data = await resp.json()
-    // clear existing options
-    chartSelect.innerHTML = ''
+// The browser attaches the DOM handlers; node (test context) skips them.
+if (typeof document !== 'undefined') registerDomHandlers()
 
-    const entries = Object.entries(data || {})
-    entries
-      .sort(([, a], [, b]) => {
-        const na = a && a.name ? String(a.name) : ''
-        const nb = b && b.name ? String(b.name) : ''
-        return na.localeCompare(nb)
-      })
-      .forEach(([id, info]) => {
-        if (info.proxy === true) {
+function registerDomHandlers() {
+  document.addEventListener('DOMContentLoaded', async () => {
+    const regionSelect = document.getElementById('region')
+    const bboxInputs = document.querySelectorAll(
+      '#bboxMinLon, #bboxMinLat, #bboxMaxLon, #bboxMaxLat'
+    )
+    const tileInputs = document.querySelectorAll('#tileX, #tileY, #tileZ')
+
+    function updateInputs() {
+      const type = document.querySelector(
+        'input[name="inputType"]:checked'
+      ).value
+
+      regionSelect.disabled = type !== 'region'
+      bboxInputs.forEach((i) => (i.disabled = type !== 'bbox'))
+      tileInputs.forEach((i) => (i.disabled = type !== 'tile'))
+    }
+
+    // Attach listeners
+    document.querySelectorAll('input[name="inputType"]').forEach((r) => {
+      r.addEventListener('change', updateInputs)
+    })
+
+    updateInputs() // initial load
+
+    if (!regionSelect) return
+
+    try {
+      const resp = await fetch('/signalk/v2/api/resources/regions')
+      if (!resp.ok) throw new Error(`Failed to fetch regions: ${resp.status}`)
+      const data = await resp.json()
+      // clear existing options
+      regionSelect.innerHTML = ''
+
+      const entries = Object.entries(data || {})
+      entries
+        .sort(([, a], [, b]) => {
+          const na = a && a.name ? String(a.name) : ''
+          const nb = b && b.name ? String(b.name) : ''
+          return na.localeCompare(nb)
+        })
+        .forEach(([id, info]) => {
           const opt = document.createElement('option')
           opt.value = id
           opt.textContent = info && info.name ? info.name : id
-          chartSelect.appendChild(opt)
+          regionSelect.appendChild(opt)
+        })
+
+      // if no regions returned, add a fallback option
+      if (!regionSelect.options.length) {
+        const opt = document.createElement('option')
+        opt.value = ''
+        opt.textContent = '-- No regions available --'
+        regionSelect.appendChild(opt)
+      }
+    } catch (err) {
+      console.error('Error loading regions:', err)
+    }
+
+    //Fetch available maps and populate the chart select box
+    const chartSelect = document.getElementById('chart')
+    if (!chartSelect) return
+
+    try {
+      const resp = await fetch('/signalk/v2/api/resources/charts')
+      if (!resp.ok) throw new Error(`Failed to fetch charts: ${resp.status}`)
+      const data = await resp.json()
+      // clear existing options
+      chartSelect.innerHTML = ''
+
+      const entries = Object.entries(data || {})
+      entries
+        .sort(([, a], [, b]) => {
+          const na = a && a.name ? String(a.name) : ''
+          const nb = b && b.name ? String(b.name) : ''
+          return na.localeCompare(nb)
+        })
+        .forEach(([id, info]) => {
+          if (info.proxy === true) {
+            const opt = document.createElement('option')
+            opt.value = id
+            opt.textContent = info && info.name ? info.name : id
+            chartSelect.appendChild(opt)
+          }
+        })
+
+      // if no maps returned, add a fallback option
+      if (!chartSelect.options.length) {
+        const opt = document.createElement('option')
+        opt.value = ''
+        opt.textContent = '-- No maps available --'
+        chartSelect.appendChild(opt)
+      }
+    } catch (err) {
+      console.error('Error loading maps:', err)
+    }
+
+    document
+      .getElementById('createJobButton')
+      .addEventListener('click', async () => {
+        try {
+          const chart = document.getElementById('chart').value
+          const regionGUID = document.getElementById('region').value
+          const maxZoom = document.getElementById('maxZoom').value
+          const bbox = {
+            minLon: parseFloat(document.getElementById('bboxMinLon').value),
+            minLat: parseFloat(document.getElementById('bboxMinLat').value),
+            maxLon: parseFloat(document.getElementById('bboxMaxLon').value),
+            maxLat: parseFloat(document.getElementById('bboxMaxLat').value)
+          }
+          // const tile = {
+          //     z: parseInt(document.getElementById('tileZ').value),
+          //     x: parseInt(document.getElementById('tileX').value),
+          //     y: parseInt(document.getElementById('tileY').value),
+
+          // };
+          // console.log(tile);
+          const type = document.querySelector(
+            'input[name="inputType"]:checked'
+          ).value
+          const body = {}
+          if (type === 'region') {
+            body.regionGUID = regionGUID
+          } else if (type === 'bbox') {
+            body.bbox = bbox
+          }
+          // else if (type === 'tile') {
+          //     body.tile = tile;
+          // }
+          body.maxZoom = maxZoom
+          await submitSeedJob(chart, body)
+          // Trigger an immediate refresh so the new job appears without waiting
+          // for the 2s polling interval.
+          fetchActiveJobs()
+        } catch (err) {
+          console.error('Error seeding charts:', err)
+          alert(`Failed to start seeding job: ${err.message}`)
         }
       })
 
-    // if no maps returned, add a fallback option
-    if (!chartSelect.options.length) {
-      const opt = document.createElement('option')
-      opt.value = ''
-      opt.textContent = '-- No maps available --'
-      chartSelect.appendChild(opt)
-    }
-  } catch (err) {
-    console.error('Error loading maps:', err)
-  }
-
-  document
-    .getElementById('createJobButton')
-    .addEventListener('click', async () => {
-      try {
-        const chart = document.getElementById('chart').value
-        const regionGUID = document.getElementById('region').value
-        const maxZoom = document.getElementById('maxZoom').value
-        const bbox = {
-          minLon: parseFloat(document.getElementById('bboxMinLon').value),
-          minLat: parseFloat(document.getElementById('bboxMinLat').value),
-          maxLon: parseFloat(document.getElementById('bboxMaxLon').value),
-          maxLat: parseFloat(document.getElementById('bboxMaxLat').value)
-        }
-        // const tile = {
-        //     z: parseInt(document.getElementById('tileZ').value),
-        //     x: parseInt(document.getElementById('tileX').value),
-        //     y: parseInt(document.getElementById('tileY').value),
-
-        // };
-        // console.log(tile);
-        const type = document.querySelector(
-          'input[name="inputType"]:checked'
-        ).value
-        const body = {}
-        if (type === 'region') {
-          body.regionGUID = regionGUID
-        } else if (type === 'bbox') {
-          body.bbox = bbox
-        }
-        // else if (type === 'tile') {
-        //     body.tile = tile;
-        // }
-        body.maxZoom = maxZoom
-        const resp = await fetch(`/signalk/chart-tiles/cache/${chart}`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json'
-          },
-          body: JSON.stringify(body)
-        })
-        if (!resp.ok) throw new Error(`Failed to seed charts: ${resp.status}`)
-        const data = await resp.json()
-      } catch (err) {
-        console.error('Error seeding charts:', err)
+    const fmt = (n) => (typeof n === 'number' ? n.toLocaleString() : '-')
+    const statusText = (s) => {
+      switch (s) {
+        case 0:
+          return 'Stopped'
+        case 1:
+          return 'Running'
+        default:
+          return String(s)
       }
-    })
-
-  const fmt = (n) => (typeof n === 'number' ? n.toLocaleString() : '-')
-  const statusText = (s) => {
-    switch (s) {
-      case 0:
-        return 'Stopped'
-      case 1:
-        return 'Running'
-      default:
-        return String(s)
-    }
-  }
-
-  function renderJobs(items) {
-    const tbody = document.querySelector('#activeJobsTable tbody')
-    if (!tbody) return
-    tbody.innerHTML = ''
-    if (!Array.isArray(items) || items.length === 0) {
-      const tr = document.createElement('tr')
-      tr.innerHTML = '<td colspan="10" class="muted">No active jobs</td>'
-      tbody.appendChild(tr)
-      return
     }
 
-    items.forEach((it, idx) => {
-      const tr = document.createElement('tr')
+    function renderJobs(items) {
+      const tbody = document.querySelector('#activeJobsTable tbody')
+      if (!tbody) return
+      tbody.innerHTML = ''
+      if (!Array.isArray(items) || items.length === 0) {
+        const tr = document.createElement('tr')
+        tr.innerHTML = '<td colspan="10" class="muted">No active jobs</td>'
+        tbody.appendChild(tr)
+        return
+      }
 
-      const pct =
-        typeof it.progress === 'number' && isFinite(it.progress)
-          ? Math.max(0, Math.min(100, it.progress * 100))
-          : 0
-      const pctText = `${pct.toFixed(1)}%`
-      tr.innerHTML = [
-        `<td>${idx + 1}</td>`,
-        `<td>${it.chartName || '-'}</td>`,
-        `<td>${it.regionName || '-'}</td>`,
-        `<td>${fmt(it.totalTiles)}</td>`,
-        `<td>${fmt(it.downloadedTiles)}</td>`,
-        `<td>${fmt(it.cachedTiles)}</td>`,
-        `<td>${fmt(it.failedTiles)}</td>`,
-        `<td>
+      items.forEach((it, idx) => {
+        const tr = document.createElement('tr')
+
+        const pct =
+          typeof it.progress === 'number' && isFinite(it.progress)
+            ? Math.max(0, Math.min(100, it.progress * 100))
+            : 0
+        const pctText = `${pct.toFixed(1)}%`
+        tr.innerHTML = [
+          `<td>${idx + 1}</td>`,
+          `<td>${it.chartName || '-'}</td>`,
+          `<td>${it.regionName || '-'}</td>`,
+          `<td>${fmt(it.totalTiles)}</td>`,
+          `<td>${fmt(it.downloadedTiles)}</td>`,
+          `<td>${fmt(it.cachedTiles)}</td>`,
+          `<td>${fmt(it.failedTiles)}</td>`,
+          `<td>
                          <span class="progress-bar" aria-hidden="true">
                              <span class="progress-fill" style="width:${pct}%"></span>
                          </span>
                          <span class="percent">${pctText}</span>
                      </td>`,
-        `<td>${statusText(it.status)}</td>`,
-        `
+          `<td>${statusText(it.status)}</td>`,
+          `
                 <td class="action-buttons">
                     <button class="btn startstop-btn" data-id="${it.id}" data-totalTiles="${it.totalTiles}" title="Start">
                         <svg class="icon-play ${it.status === 1 ? 'hidden' : ''}" viewBox="0 0 24 24" width="16" height="16" fill="white">
@@ -209,102 +247,103 @@ document.addEventListener('DOMContentLoaded', async () => {
                     </button>
                 </td>
                     `
-      ].join('')
+        ].join('')
 
-      tr.querySelectorAll('.startstop-btn').forEach((button) => {
-        button.addEventListener('click', () => {
-          const playIcon = button.querySelector('.icon-play')
-          const pauseIcon = button.querySelector('.icon-pause')
-          const jobId = button.getAttribute('data-id')
-          const totalTiles = button.getAttribute('data-totalTiles')
-          const isRunning = pauseIcon.classList.contains('hidden')
-          console.log(isRunning)
-          if (isRunning) {
-            // Switch to stop
+        tr.querySelectorAll('.startstop-btn').forEach((button) => {
+          button.addEventListener('click', () => {
+            const playIcon = button.querySelector('.icon-play')
+            const pauseIcon = button.querySelector('.icon-pause')
+            const jobId = button.getAttribute('data-id')
+            const totalTiles = button.getAttribute('data-totalTiles')
+            const isRunning = pauseIcon.classList.contains('hidden')
+            console.log(isRunning)
+            if (isRunning) {
+              // Switch to stop
+              if (
+                totalTiles > 100000 &&
+                !confirm(
+                  `This job has more than ${totalTiles} tiles to download. Starting it may take a long time and put high load on the server. Are you sure you want to start it?`
+                )
+              ) {
+                return
+              }
+              takeAction(jobId, 'start')
+              button.title = 'Stop'
+            } else {
+              // Switch to start
+              takeAction(jobId, 'stop')
+              button.title = 'Start'
+            }
+          })
+        })
+
+        tr.querySelectorAll('.delete-btn').forEach((button) => {
+          button.addEventListener('click', () => {
             if (
-              totalTiles > 100000 &&
-              !confirm(
-                `This job has more than ${totalTiles} tiles to download. Starting it may take a long time and put high load on the server. Are you sure you want to start it?`
+              confirm(
+                'This will delete all cached tiles for this job. Are you sure?'
               )
             ) {
-              return
+              const jobId = button.getAttribute('data-id')
+              if (jobId) {
+                takeAction(jobId, 'delete')
+              }
             }
-            takeAction(jobId, 'start')
-            button.title = 'Stop'
-          } else {
-            // Switch to start
-            takeAction(jobId, 'stop')
-            button.title = 'Start'
-          }
+          })
         })
-      })
 
-      tr.querySelectorAll('.delete-btn').forEach((button) => {
-        button.addEventListener('click', () => {
-          if (
-            confirm(
-              'This will delete all cached tiles for this job. Are you sure?'
-            )
-          ) {
+        tr.querySelectorAll('.remove-btn').forEach((button) => {
+          button.addEventListener('click', () => {
             const jobId = button.getAttribute('data-id')
             if (jobId) {
-              takeAction(jobId, 'delete')
+              takeAction(jobId, 'remove')
             }
-          }
+          })
         })
+
+        tbody.appendChild(tr)
       })
 
-      tr.querySelectorAll('.remove-btn').forEach((button) => {
-        button.addEventListener('click', () => {
-          const jobId = button.getAttribute('data-id')
-          if (jobId) {
-            takeAction(jobId, 'remove')
-          }
+      function takeAction(jobId, action) {
+        fetch(`/signalk/chart-tiles/cache/jobs/${jobId}`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({
+            action: action
+          })
         })
-      })
-
-      tbody.appendChild(tr)
-    })
-
-    function takeAction(jobId, action) {
-      fetch(`/signalk/chart-tiles/cache/jobs/${jobId}`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({
-          action: action
-        })
-      })
-        .then((response) => {
-          if (!response.ok) {
-            throw new Error(
-              `Failed to ${action} job ${jobId}: ${response.status}`
-            )
-          }
-          fetchActiveJobs()
-        })
-        .catch((error) => {
-          console.error(`Error ${action} job:`, error)
-        })
+          .then((response) => {
+            if (!response.ok) {
+              throw new Error(
+                `Failed to ${action} job ${jobId}: ${response.status}`
+              )
+            }
+            fetchActiveJobs()
+          })
+          .catch((error) => {
+            console.error(`Error ${action} job:`, error)
+          })
+      }
     }
-  }
 
-  async function fetchActiveJobs() {
-    const tbody = document.querySelector('#activeJobsTable tbody')
-    try {
-      const resp = await fetch('/signalk/chart-tiles/cache/jobs')
-      if (!resp.ok) throw new Error('HTTP ' + resp.status)
-      const data = await resp.json()
-      renderJobs(data)
-    } catch (err) {
-      console.error('Error fetching active jobs:', err)
-      tbody.innerHTML =
-        '<tr><td colspan="10" class="muted">Error loading active jobs</td></tr>'
+    async function fetchActiveJobs() {
+      const tbody = document.querySelector('#activeJobsTable tbody')
+      try {
+        const resp = await fetch('/signalk/chart-tiles/cache/jobs')
+        if (!resp.ok) throw new Error('HTTP ' + resp.status)
+        const data = await resp.json()
+        renderJobs(data)
+      } catch (err) {
+        console.error('Error fetching active jobs:', err)
+        tbody.innerHTML =
+          '<tr><td colspan="10" class="muted">Error loading active jobs</td></tr>'
+      }
     }
-  }
 
-  fetchActiveJobs()
-  // refresh every 2 seconds
-  setInterval(fetchActiveJobs, 2000)
-})
+    fetchActiveJobs()
+    // refresh every 2 seconds
+    setInterval(fetchActiveJobs, 2000)
+  })
+}

--- a/src/chartDownloader.ts
+++ b/src/chartDownloader.ts
@@ -17,6 +17,7 @@ import checkDiskSpace from 'check-disk-space'
 import { ResourcesApi } from '@signalk/server-api'
 import { ChartProvider } from './types'
 import { lonLatToMercator, lonLatToTile, tileToBBox } from './projection'
+import { MIN_ZOOM } from './tileServer'
 
 export interface Tile {
   x: number
@@ -140,9 +141,10 @@ export class ChartDownloader {
     this.areaDescription = `Tile: [${tile.x}, ${tile.y}, ${tile.z}]`
   }
 
+  private static DISK_CHECK_INTERVAL_MS = 30_000
+
   /**
    * Download map tiles for a specific area.
-   *
    */
   async seedCache(): Promise<void> {
     // Guard against double-start: a second call while Running would share
@@ -156,13 +158,17 @@ export class ChartDownloader {
     this.failedTiles = 0
     this.cachedTiles = this.totalTiles - this.tilesToDownload.length
     const limit = pLimit(this.concurrentDownloadsLimit) // concurrent download limit
-    let tileCounter = 0
+    let lastDiskCheck = 0
 
     const tasks = this.tilesToDownload.map((tile) =>
       limit(async () => {
         if (this.cancelRequested) return
-        if (tileCounter % 1000 === 0) {
-          await new Promise((r) => setTimeout(r, 0))
+        // Time-based (rather than tile-count-based) disk-space probing: a
+        // tight per-1000-tile cadence fired hundreds of times on a large
+        // bbox, whereas real disk consumption grows with wall-clock time.
+        const now = Date.now()
+        if (now - lastDiskCheck >= ChartDownloader.DISK_CHECK_INTERVAL_MS) {
+          lastDiskCheck = now
           try {
             const { free } = await checkDiskSpace(this.chartsPath)
             if (free < ChartDownloader.MINIMUM_FREE_DISK_SPACE) {
@@ -176,7 +182,6 @@ export class ChartDownloader {
             return
           }
         }
-        tileCounter++
         const buffer = await ChartDownloader.getTileFromCacheOrRemote(
           this.chartsPath,
           this.provider,
@@ -194,10 +199,14 @@ export class ChartDownloader {
       })
     )
 
-    try {
-      await Promise.all(tasks)
-    } catch (err) {
-      console.error('Error downloading tiles:', err)
+    // allSettled ensures every in-flight task completes before we flip back
+    // to Stopped; Promise.all would resolve on the first rejection while
+    // other tasks still incremented counters in the background.
+    const results = await Promise.allSettled(tasks)
+    for (const r of results) {
+      if (r.status === 'rejected') {
+        console.error('Error downloading tile:', r.reason)
+      }
     }
     this.status = Status.Stopped
   }
@@ -316,8 +325,10 @@ export class ChartDownloader {
     tile: Tile,
     timeoutMs = 5000
   ): Promise<Buffer | null> {
+    // Local (non-proxy) providers have no remoteUrl; the POST /cache endpoint
+    // is open to any provider, so callers can still land here and should get
+    // a well-defined null rather than a crash.
     if (!provider.remoteUrl) {
-      console.error(`No remote URL defined for provider ${provider.name}`)
       return null
     }
     let url = provider.remoteUrl
@@ -349,22 +360,24 @@ export class ChartDownloader {
       }
     }
     const controller = new AbortController()
-    const id = setTimeout(() => controller.abort(), timeoutMs)
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
     try {
       const response = await fetch(url, {
         headers: provider.headers,
         signal: controller.signal
       })
+      // Clear the abort timer as soon as the response head is in. A long body
+      // read was otherwise racing the timeout and could be aborted mid-stream
+      // while the caller waited on arrayBuffer().
+      clearTimeout(timeoutId)
       if (!response.ok) {
         return null
       }
       const arrayBuffer = await response.arrayBuffer()
-      const buffer = Buffer.from(arrayBuffer)
-      return buffer
-    } catch (err) {
+      return Buffer.from(arrayBuffer)
+    } catch (_err) {
+      clearTimeout(timeoutId)
       return null
-    } finally {
-      clearTimeout(id)
     }
   }
 
@@ -399,7 +412,7 @@ export class ChartDownloader {
     const crossesAntiMeridian = minLon > maxLon
     // Respect the provider's minzoom: low zooms outside the provider's range
     // would 404 from the remote and just inflate totalTiles.
-    const minZoom = Math.max(1, this.provider.minzoom ?? 1)
+    const minZoom = Math.max(MIN_ZOOM, this.provider.minzoom ?? MIN_ZOOM)
 
     // Helper to process a lon/lat box normally. lonLatToTileXY returns
     // tile-Y increasing southward, so for a box with minLat < maxLat the

--- a/src/charts.ts
+++ b/src/charts.ts
@@ -2,7 +2,7 @@ import path from 'path'
 import { XMLParser } from 'fast-xml-parser'
 import { Dirent, promises as fs } from 'fs'
 import pLimit from 'p-limit'
-import { ChartProvider } from './types'
+import { ChartProvider, MBTilesHandle, MBTilesMetadata } from './types'
 
 // Parses tilemapresource.xml into a plain object. ignoreAttributes=false and
 // attributeNamePrefix='' drop the default '@_' prefix so XML attributes show
@@ -31,9 +31,14 @@ const xmlParser = new XMLParser({
   parseAttributeValue: false
 })
 
-// Dynamically load MBTiles to prevent module load failure
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let MBTiles: any = null
+type MBTilesConstructor = new (
+  file: string,
+  callback: (err: Error | null, mbtiles: MBTilesHandle) => void
+) => MBTilesHandle
+
+// Dynamically load MBTiles to prevent module load failure when the native
+// SQLite dependency is unavailable (e.g. bare test environments).
+let MBTiles: MBTilesConstructor | null = null
 let mbtilesLoadError: Error | null = null
 
 async function loadMBTiles() {
@@ -133,67 +138,87 @@ async function scanDir(
   await Promise.all(tasks)
 }
 
-function openMbtilesFile(file: string, filename: string) {
-  return (
-    new Promise((resolve, reject) => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      new MBTiles(file, (err: Error, mbtiles: any) => {
-        if (err) {
-          return reject(err)
-        }
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        mbtiles.getInfo((err: Error, metadata: any) => {
-          if (err) {
-            return reject(err)
-          }
-          return resolve({ mbtiles, metadata })
-        })
+interface LoadedMbtiles {
+  mbtiles: MBTilesHandle
+  metadata: MBTilesMetadata
+}
+
+function openMbtilesFile(
+  file: string,
+  filename: string
+): Promise<ChartProvider | null> {
+  return new Promise<LoadedMbtiles>((resolve, reject) => {
+    if (!MBTiles) {
+      reject(mbtilesLoadError ?? new Error('MBTiles module not loaded'))
+      return
+    }
+    new MBTiles(file, (err, mbtiles) => {
+      if (err) return reject(err)
+      mbtiles.getInfo((infoErr, metadata) => {
+        if (infoErr) return reject(infoErr)
+        resolve({ mbtiles, metadata })
       })
     })
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      .then((res: any) => {
-        if (
-          !res.metadata ||
-          Object.keys(res.metadata).length === 0 ||
-          res.metadata.bounds === undefined
-        ) {
-          return null
-        }
-        const identifier = filename.replace(/\.mbtiles$/i, '')
-        const data: ChartProvider = {
-          _fileFormat: 'mbtiles',
-          _filePath: file,
-          _mbtilesHandle: res.mbtiles,
-          _flipY: false,
-          identifier,
-          name: res.metadata.name || res.metadata.id,
-          description: res.metadata.description,
-          bounds: res.metadata.bounds,
-          minzoom: res.metadata.minzoom,
-          maxzoom: res.metadata.maxzoom,
-          format: res.metadata.format,
-          type: 'tilelayer',
-          scale: parseInt(res.metadata.scale) || 250000,
-          v1: {
-            tilemapUrl: `~tilePath~/${identifier}/{z}/{x}/{y}`,
-            chartLayers: res.metadata.vector_layers
-              ? parseVectorLayers(res.metadata.vector_layers)
-              : []
-          },
-          v2: {
-            url: `~tilePath~/${identifier}/{z}/{x}/{y}`,
-            layers: res.metadata.vector_layers
-              ? parseVectorLayers(res.metadata.vector_layers)
-              : []
-          }
-        }
-        return data
-      })
-      .catch((e: Error) => {
-        console.error(`Error loading chart ${file}`, e.message)
+  })
+    .then(({ mbtiles, metadata }) => {
+      if (
+        !metadata ||
+        Object.keys(metadata).length === 0 ||
+        metadata.bounds === undefined
+      ) {
         return null
-      })
-  )
+      }
+      const identifier = filename.replace(/\.mbtiles$/i, '')
+      const boundsArray = parseBoundsFromMetadata(metadata.bounds)
+      const data: ChartProvider = {
+        _fileFormat: 'mbtiles',
+        _filePath: file,
+        _mbtilesHandle: mbtiles,
+        _flipY: false,
+        identifier,
+        name: metadata.name || metadata.id || identifier,
+        description: metadata.description ?? '',
+        bounds: boundsArray,
+        minzoom: metadata.minzoom,
+        maxzoom: metadata.maxzoom,
+        format: metadata.format,
+        type: 'tilelayer',
+        scale: parseInt(metadata.scale ?? '') || 250000,
+        v1: {
+          tilemapUrl: `~tilePath~/${identifier}/{z}/{x}/{y}`,
+          chartLayers: metadata.vector_layers
+            ? parseVectorLayers(metadata.vector_layers)
+            : []
+        },
+        v2: {
+          url: `~tilePath~/${identifier}/{z}/{x}/{y}`,
+          layers: metadata.vector_layers
+            ? parseVectorLayers(metadata.vector_layers)
+            : []
+        }
+      }
+      return data
+    })
+    .catch((e: Error) => {
+      console.error(`Error loading chart ${file}`, e.message)
+      return null
+    })
+}
+
+// MBTiles spec stores bounds as "minLon,minLat,maxLon,maxLat"; some writers
+// normalise it to an array already. Accept both.
+function parseBoundsFromMetadata(
+  bounds: number[] | string | undefined
+): number[] | undefined {
+  if (bounds === undefined) return undefined
+  if (Array.isArray(bounds)) return bounds
+  if (typeof bounds === 'string') {
+    const parts = bounds.split(',').map((b) => parseFloat(b.trim()))
+    return parts.length === 4 && parts.every(Number.isFinite)
+      ? parts
+      : undefined
+  }
+  return undefined
 }
 
 function parseVectorLayers(layers: Array<{ id: string }>) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,10 +3,19 @@ import fs, { FSWatcher } from 'fs'
 import * as _ from 'lodash'
 import { findCharts } from './charts'
 import { apiRoutePrefix } from './constants'
-import { ChartProvider, OnlineChartProvider } from './types'
-import { ChartSeedingManager, ChartDownloader, Tile } from './chartDownloader'
+import { ChartProvider, MBTilesHandle, OnlineChartProvider } from './types'
+import { ChartSeedingManager, Tile } from './chartDownloader'
+import {
+  MAX_ZOOM,
+  MIN_ZOOM,
+  serveTileFromCacheOrRemote,
+  serveTileFromFilesystem,
+  serveTileFromMbtiles,
+  validateBBox,
+  validateMaxZoom,
+  validateTileCoords
+} from './tileServer'
 import { Request, Response, Application } from 'express'
-import { OutgoingHttpHeaders } from 'http'
 import {
   Plugin,
   ServerAPI,
@@ -29,8 +38,6 @@ interface ChartProviderApp
   }
 }
 
-const MIN_ZOOM = 1
-const MAX_ZOOM = 24
 const chartTilesPath = '/signalk/chart-tiles'
 // Debounce window used to collapse FSWatcher bursts during rename / atomic-save
 // sequences into one reload. Overridable via env var so tests don't have to
@@ -391,11 +398,10 @@ const createPlugin = (app: ChartProviderApp): Plugin => {
     }
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const closeMbtilesHandle = (handle: any) => {
+  const closeMbtilesHandle = (handle: MBTilesHandle) => {
     if (typeof handle?.close !== 'function') return
     try {
-      handle.close((err: Error | null) => {
+      handle.close((err) => {
         if (err) app.debug(`MBTiles close error: ${err.message}`)
       })
     } catch (err) {
@@ -478,15 +484,26 @@ const createPlugin = (app: ChartProviderApp): Plugin => {
         if (!identifier || !z || !x || !y) {
           return res.sendStatus(404)
         }
+        const iz = parseInt(z)
         const ix = parseInt(x)
         const iy = parseInt(y)
-        const iz = parseInt(z)
+        const coordError = validateTileCoords(iz, ix, iy)
+        if (coordError) {
+          return res.status(400).send(coordError)
+        }
         const provider = chartProviders[identifier]
         if (!provider) {
           return res.sendStatus(404)
         }
         if (provider.proxy === true) {
-          return serveTileFromCacheOrRemote(res, provider, iz, ix, iy)
+          return serveTileFromCacheOrRemote(
+            res,
+            cachePath,
+            provider,
+            iz,
+            ix,
+            iy
+          )
         } else {
           switch (provider._fileFormat) {
             case 'directory':
@@ -494,7 +511,7 @@ const createPlugin = (app: ChartProviderApp): Plugin => {
             case 'mbtiles':
               return serveTileFromMbtiles(res, provider, iz, ix, iy)
             default:
-              console.log(
+              app.debug(
                 `Unknown chart provider fileformat ${provider._fileFormat}`
               )
               res.status(500).send()
@@ -534,6 +551,22 @@ const createPlugin = (app: ChartProviderApp): Plugin => {
             .send('Request must include regionGUID, bbox, or tile')
         }
         const maxZoomParsed = parseInt(maxZoom)
+        const zoomError = validateMaxZoom(maxZoomParsed)
+        if (zoomError) {
+          return res.status(400).send(zoomError)
+        }
+        if (bbox) {
+          const bboxError = validateBBox(bbox)
+          if (bboxError) {
+            return res.status(400).send(bboxError)
+          }
+        }
+        if (tile) {
+          const tileError = validateTileCoords(tile.z, tile.x, tile.y)
+          if (tileError) {
+            return res.status(400).send(tileError)
+          }
+        }
         try {
           const job = await ChartSeedingManager.createJob(
             app.resourcesApi,
@@ -573,9 +606,6 @@ const createPlugin = (app: ChartProviderApp): Plugin => {
           return res.sendStatus(404)
         }
         const { action } = req.body as { action: string }
-        if (!id) {
-          return res.status(400).send('Missing job id')
-        }
         const parsedId = parseInt(id)
         if (!Number.isFinite(parsedId)) {
           return res.status(400).send(`Invalid job id: ${id}`)
@@ -665,44 +695,10 @@ const createPlugin = (app: ChartProviderApp): Plugin => {
     }
   }
 
-  const serveTileFromCacheOrRemote = async (
-    res: Response,
-    provider: ChartProvider,
-    z: number,
-    x: number,
-    y: number
-  ) => {
-    const buffer = await ChartDownloader.getTileFromCacheOrRemote(
-      cachePath,
-      provider,
-      { x, y, z }
-    )
-    if (!buffer) {
-      res.sendStatus(502)
-      return
-    }
-    res.set('Content-Type', `image/${provider.format}`)
-    res.send(buffer)
-  }
-
   return plugin
 }
 
 export = createPlugin
-
-const responseHttpOptions = {
-  headers: {
-    'Cache-Control': 'public, max-age=7776000' // 90 days
-  }
-}
-
-// Allowed tile file formats. Add new formats here when supporting them.
-const ALLOWED_TILE_FORMATS = new Set(['png', 'jpg', 'jpeg', 'pbf'])
-
-const isAllowedTileFormat = (format: string | undefined): boolean => {
-  if (!format) return false
-  return ALLOWED_TILE_FORMATS.has(format.toLowerCase())
-}
 
 const resolveUniqueChartPaths = (
   chartPaths: string[],
@@ -741,8 +737,8 @@ const convertOnlineProviderConfig = (provider: OnlineChartProvider) => {
     name: provider.name,
     description: provider.description,
     bounds: [-180, -90, 180, 90],
-    minzoom: Math.min(Math.max(1, provider.minzoom), 24),
-    maxzoom: Math.min(Math.max(1, provider.maxzoom), 24),
+    minzoom: Math.min(Math.max(MIN_ZOOM, provider.minzoom), MAX_ZOOM),
+    maxzoom: Math.min(Math.max(MIN_ZOOM, provider.maxzoom), MAX_ZOOM),
     format: provider.format,
     scale: 250000,
     type: provider.serverType ? provider.serverType : 'tilelayer',
@@ -798,77 +794,4 @@ const ensureDirectoryExists = async (p: string) => {
   // mkdir with recursive:true is idempotent and skips the existsSync probe,
   // keeping startup off the sync-fs path.
   await fs.promises.mkdir(p, { recursive: true })
-}
-
-const serveTileFromFilesystem = async (
-  res: Response,
-  provider: ChartProvider,
-  z: number,
-  x: number,
-  y: number
-) => {
-  const { format, _flipY, _filePath } = provider
-  const normalizedFormat = format?.toLowerCase() ?? ''
-  if (!_filePath || !ALLOWED_TILE_FORMATS.has(normalizedFormat)) {
-    res.sendStatus(404)
-    return
-  }
-  const flippedY = Math.pow(2, z) - 1 - y
-  const file = path.resolve(
-    _filePath,
-    `${z}/${x}/${_flipY ? flippedY : y}.${normalizedFormat}`
-  )
-  try {
-    const stats = await fs.promises.stat(file)
-    if (!stats.isFile()) {
-      res.sendStatus(404)
-      return
-    }
-    await fs.promises.access(file, fs.constants.R_OK)
-  } catch {
-    res.sendStatus(404)
-    return
-  }
-  res.sendFile(file, responseHttpOptions)
-}
-
-const serveTileFromMbtiles = (
-  res: Response,
-  provider: ChartProvider,
-  z: number,
-  x: number,
-  y: number
-) => {
-  if (!isAllowedTileFormat(provider.format)) {
-    res.sendStatus(404)
-    return
-  }
-  // Guard against a provider whose MBTiles handle is missing: openMbtilesFile
-  // may have failed post-reconcile, or the handle was closed while a request
-  // was in flight. Without this check, `.getTile` throws synchronously and
-  // Express never answers the client.
-  if (!provider._mbtilesHandle) {
-    res.sendStatus(500)
-    return
-  }
-  provider._mbtilesHandle.getTile(
-    z,
-    x,
-    y,
-    (err: Error, tile: Buffer, headers: OutgoingHttpHeaders) => {
-      if (err && err.message && err.message === 'Tile does not exist') {
-        res.sendStatus(404)
-      } else if (err) {
-        console.error(
-          `Error fetching tile ${provider.identifier}/${z}/${x}/${y}:`,
-          err
-        )
-        res.sendStatus(500)
-      } else {
-        headers['Cache-Control'] = responseHttpOptions.headers['Cache-Control']
-        res.writeHead(200, headers)
-        res.end(tile)
-      }
-    }
-  )
 }

--- a/src/projection.ts
+++ b/src/projection.ts
@@ -9,8 +9,22 @@ export const WEB_MERCATOR_HALF_EXTENT_M = 20037508.34
 // limit used by OSM / Google / MapBox tile schemes.
 export const WEB_MERCATOR_MAX_LAT = 85.0511287798
 
+// Web Mercator tile → WGS84 bounding box.
+// Input  (x=1, y=1, z=2): tile (1,1) at zoom 2 — one of sixteen.
+// Output: [minLon, minLat, maxLon, maxLat] for that tile in degrees.
+// x and y must be inside the grid ([0, 2^z)); out-of-range inputs produced
+// nonsense coordinates that silently fed downstream bbox math. Fail fast.
 export function tileToBBox(x: number, y: number, z: number): BBox {
+  if (!Number.isInteger(z) || z < 0) {
+    throw new RangeError(`tileToBBox: invalid zoom ${z}`)
+  }
   const n = 2 ** z
+  if (!Number.isInteger(x) || x < 0 || x >= n) {
+    throw new RangeError(`tileToBBox: x=${x} out of range at z=${z}`)
+  }
+  if (!Number.isInteger(y) || y < 0 || y >= n) {
+    throw new RangeError(`tileToBBox: y=${y} out of range at z=${z}`)
+  }
   const lon1 = (x / n) * 360 - 180
   const lat1 =
     (Math.atan(Math.sinh(Math.PI * (1 - (2 * y) / n))) * 180) / Math.PI

--- a/src/tileServer.ts
+++ b/src/tileServer.ts
@@ -1,0 +1,202 @@
+import path from 'path'
+import { Response } from 'express'
+import { OutgoingHttpHeaders } from 'http'
+import { ChartProvider } from './types'
+import { ChartDownloader } from './chartDownloader'
+
+/**
+ * Tile-serving HTTP helpers for the charts plugin. Each helper terminates
+ * the Express response itself; callers only pick the branch based on the
+ * provider's storage format.
+ */
+
+// Provider-config zoom range: what we allow users to configure in the plugin
+// settings for a chart's minzoom/maxzoom.
+export const MIN_ZOOM = 1
+export const MAX_ZOOM = 24
+
+// Tile-coordinate range accepted on the HTTP tile route. Starts at zero
+// because Leaflet's default minZoom is 0 — clients legitimately ask for
+// the world tile when framing the initial view, even if no configured
+// provider covers that level (they just get a 404 per-tile).
+export const MIN_TILE_Z = 0
+
+export const responseHttpOptions = {
+  headers: {
+    'Cache-Control': 'public, max-age=7776000' // 90 days
+  }
+}
+
+// Tile file extensions recognised on the filesystem path. Add new entries
+// here when a new raster or vector format is supported.
+const ALLOWED_TILE_FORMATS = new Set(['png', 'jpg', 'jpeg', 'pbf'])
+
+export const isAllowedTileFormat = (format: string | undefined): boolean => {
+  if (!format) return false
+  return ALLOWED_TILE_FORMATS.has(format.toLowerCase())
+}
+
+// Validates tile coordinates submitted by callers. Zoom is constrained to
+// the range the plugin advertises; x/y must fit the zoom grid.
+// Returns an error message if invalid, or undefined if OK.
+export const validateTileCoords = (
+  z: number,
+  x: number,
+  y: number
+): string | undefined => {
+  if (!Number.isInteger(z) || z < MIN_TILE_Z || z > MAX_ZOOM) {
+    return `Invalid zoom ${z} (must be an integer in [${MIN_TILE_Z}, ${MAX_ZOOM}])`
+  }
+  const n = 2 ** z
+  if (!Number.isInteger(x) || x < 0 || x >= n) {
+    return `Invalid x ${x} at zoom ${z} (must be an integer in [0, ${n}))`
+  }
+  if (!Number.isInteger(y) || y < 0 || y >= n) {
+    return `Invalid y ${y} at zoom ${z} (must be an integer in [0, ${n}))`
+  }
+  return undefined
+}
+
+export const validateMaxZoom = (maxZoom: number): string | undefined => {
+  if (!Number.isFinite(maxZoom) || maxZoom < MIN_ZOOM || maxZoom > MAX_ZOOM) {
+    return `Invalid maxZoom ${maxZoom} (must be in [${MIN_ZOOM}, ${MAX_ZOOM}])`
+  }
+  return undefined
+}
+
+// Validates a caller-supplied bounding box. Lat/Lon must be finite numbers in
+// the real-world range; minLat must be below maxLat so downstream tile math
+// doesn't silently iterate an empty or inverted span. minLon > maxLon is
+// allowed — that's how antimeridian-crossing boxes are expressed.
+export const validateBBox = (bbox: {
+  minLon: unknown
+  minLat: unknown
+  maxLon: unknown
+  maxLat: unknown
+}): string | undefined => {
+  const { minLon, minLat, maxLon, maxLat } = bbox
+  const finite = (v: unknown): v is number =>
+    typeof v === 'number' && Number.isFinite(v)
+  if (
+    !finite(minLon) ||
+    !finite(minLat) ||
+    !finite(maxLon) ||
+    !finite(maxLat)
+  ) {
+    return 'bbox must contain finite numbers for minLon, minLat, maxLon, maxLat'
+  }
+  if (minLon < -180 || minLon > 180 || maxLon < -180 || maxLon > 180) {
+    return 'bbox longitude must be in [-180, 180]'
+  }
+  if (minLat < -90 || minLat > 90 || maxLat < -90 || maxLat > 90) {
+    return 'bbox latitude must be in [-90, 90]'
+  }
+  if (minLat >= maxLat) {
+    return 'bbox minLat must be less than maxLat'
+  }
+  return undefined
+}
+
+export const serveTileFromFilesystem = (
+  res: Response,
+  provider: ChartProvider,
+  z: number,
+  x: number,
+  y: number
+) => {
+  const { format, _flipY, _filePath } = provider
+  const normalizedFormat = format?.toLowerCase() ?? ''
+  if (!_filePath || !ALLOWED_TILE_FORMATS.has(normalizedFormat)) {
+    res.sendStatus(404)
+    return
+  }
+  const flippedY = Math.pow(2, z) - 1 - y
+  const file = path.resolve(
+    _filePath,
+    `${z}/${x}/${_flipY ? flippedY : y}.${normalizedFormat}`
+  )
+  // sendFile already performs the stat and handles the error; the previous
+  // stat+access probe duplicated that work on every tile request. Its
+  // callback fires once per request with an err only when something went
+  // wrong (missing file, permission denied, header-already-sent aborts).
+  res.sendFile(file, responseHttpOptions, (err) => {
+    if (!err) return
+    const code = (err as NodeJS.ErrnoException).code
+    if (code === 'ENOENT' || code === 'EACCES' || code === 'EISDIR') {
+      if (!res.headersSent) res.sendStatus(404)
+    } else if (!res.headersSent) {
+      res.sendStatus(500)
+    }
+  })
+}
+
+export const serveTileFromMbtiles = (
+  res: Response,
+  provider: ChartProvider,
+  z: number,
+  x: number,
+  y: number
+) => {
+  if (!isAllowedTileFormat(provider.format)) {
+    res.sendStatus(404)
+    return
+  }
+  // Guard against a provider whose MBTiles handle is missing: openMbtilesFile
+  // may have failed post-reconcile, or the handle was closed while a request
+  // was in flight. Without this check, .getTile throws synchronously and
+  // Express never answers the client.
+  if (!provider._mbtilesHandle) {
+    res.sendStatus(500)
+    return
+  }
+  provider._mbtilesHandle.getTile(
+    z,
+    x,
+    y,
+    (err: Error | null, tile: Buffer, headers: OutgoingHttpHeaders) => {
+      if (err && isMbtilesTileMissing(err)) {
+        res.sendStatus(404)
+      } else if (err) {
+        console.error(
+          `Error fetching tile ${provider.identifier}/${z}/${x}/${y}:`,
+          err
+        )
+        res.sendStatus(500)
+      } else {
+        headers['Cache-Control'] = responseHttpOptions.headers['Cache-Control']
+        res.writeHead(200, headers)
+        res.end(tile)
+      }
+    }
+  )
+}
+
+// @signalk/mbtiles currently throws `Error('Tile does not exist')` for a
+// missing tile; some forks expose an ENOENT-style code instead. Centralise
+// the check so a future library change only requires an edit here.
+export const isMbtilesTileMissing = (err: Error): boolean => {
+  if (err.message === 'Tile does not exist') return true
+  const code = (err as NodeJS.ErrnoException).code
+  return code === 'ENOENT'
+}
+
+export const serveTileFromCacheOrRemote = async (
+  res: Response,
+  cachePath: string,
+  provider: ChartProvider,
+  z: number,
+  x: number,
+  y: number
+) => {
+  const buffer = await ChartDownloader.getTileFromCacheOrRemote(
+    cachePath,
+    provider,
+    { x, y, z }
+  )
+  if (!buffer) {
+    res.sendStatus(502)
+    return
+  }
+  res.set('Content-Type', `image/${provider.format}`)
+  res.send(buffer)
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { OutgoingHttpHeaders } from 'http'
+
 type MapSourceType =
   | 'tilelayer'
   | 'S-57'
@@ -6,11 +8,45 @@ type MapSourceType =
   | 'mapstyleJSON'
   | 'tileJSON'
 
+// Shape of the @signalk/mbtiles handle as the plugin uses it. The library is
+// CJS and untyped, so we describe the call sites rather than re-declaring the
+// full module surface.
+export interface MBTilesHandle {
+  getTile: (
+    z: number,
+    x: number,
+    y: number,
+    callback: (
+      err: Error | null,
+      tile: Buffer,
+      headers: OutgoingHttpHeaders
+    ) => void
+  ) => void
+  getInfo: (
+    callback: (err: Error | null, metadata: MBTilesMetadata) => void
+  ) => void
+  close: (callback: (err: Error | null) => void) => void
+}
+
+// MBTiles metadata rows relevant to the plugin. `bounds` is commonly a
+// comma-separated string in the spec but some writers emit an array; both
+// are tolerated at parse time.
+export interface MBTilesMetadata {
+  name?: string
+  id?: string
+  description?: string
+  bounds?: number[] | string
+  minzoom?: number
+  maxzoom?: number
+  format?: string
+  scale?: string
+  vector_layers?: Array<{ id: string }>
+}
+
 export interface ChartProvider {
   _fileFormat?: 'mbtiles' | 'directory'
   _filePath: string
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  _mbtilesHandle?: any
+  _mbtilesHandle?: MBTilesHandle
   _flipY?: boolean
   identifier: string
   name: string

--- a/test/chartDownloader-test.ts
+++ b/test/chartDownloader-test.ts
@@ -1,0 +1,171 @@
+/**
+ * Unit tests for chartDownloader.ts. Focuses on the pure tile-math methods
+ * (getTilesForBBox, getSubTiles, getTilesForGeoJSON) that form the foundation
+ * of every seed job. The stateful seeding flow is covered end-to-end in
+ * plugin-test.ts.
+ */
+
+import { expect } from 'chai'
+import type { FeatureCollection } from 'geojson'
+import { ChartDownloader, Tile } from '../src/chartDownloader'
+import { ChartProvider } from '../src/types'
+
+// Minimal provider scaffold; only the fields the tile-math methods read must
+// be populated (minzoom, name, format). Using an as-cast rather than a full
+// mock to keep the intent obvious.
+const makeProvider = (overrides: Partial<ChartProvider> = {}): ChartProvider =>
+  ({
+    identifier: 'unit',
+    name: 'unit',
+    description: '',
+    type: 'tilelayer',
+    scale: 250000,
+    format: 'png',
+    minzoom: 1,
+    maxzoom: 10,
+    _filePath: '',
+    ...overrides
+  }) as ChartProvider
+
+const makeDownloader = (provider: ChartProvider) => {
+  // The resources API and charts path are only touched by seed/init flows,
+  // not by the pure tile-math methods under test here.
+  return new ChartDownloader(
+    {} as unknown as Parameters<
+      typeof ChartDownloader.prototype.initializeJobFromRegion
+    >[0] extends never
+      ? never
+      : never,
+    '/tmp/unused',
+    provider
+  )
+}
+
+describe('chartDownloader: getTilesForBBox', () => {
+  it('returns a single tile for a small bbox at the provider minzoom', () => {
+    // A point well inside a single tile at z=3 should yield exactly one tile,
+    // not three or thirty — this is a regression guard against the loop ever
+    // expanding beyond the bbox.
+    const dl = makeDownloader(makeProvider({ minzoom: 3 }))
+    const tiles = dl.getTilesForBBox([5, 5, 6, 6], 3)
+    expect(tiles.length).to.equal(1)
+    expect(tiles[0]!.z).to.equal(3)
+  })
+
+  it('respects the provider minzoom (does not emit tiles below it)', () => {
+    const dl = makeDownloader(makeProvider({ minzoom: 3 }))
+    const tiles = dl.getTilesForBBox([5, 5, 6, 6], 5)
+    // z=3, 4, 5 → 3 tiles for a small bbox that fits in one tile per zoom
+    expect(tiles.map((t) => t.z).sort()).to.deep.equal([3, 4, 5])
+  })
+
+  it('splits an antimeridian-crossing bbox into tiles on both sides', () => {
+    // A bbox that straddles the 180° line — expressed with minLon > maxLon
+    // per the convention used throughout the code. The split path should
+    // emit tiles from both the eastern and western halves of the grid.
+    const dl = makeDownloader(makeProvider({ minzoom: 3 }))
+    const tiles = dl.getTilesForBBox([170, -5, -170, 5], 3)
+    const halfGrid = 2 ** 3 / 2
+    const easternSide = tiles.some((t) => t.x >= halfGrid)
+    const westernSide = tiles.some((t) => t.x < halfGrid)
+    expect(easternSide, 'expected tiles east of the antimeridian').to.equal(
+      true
+    )
+    expect(westernSide, 'expected tiles west of the antimeridian').to.equal(
+      true
+    )
+  })
+
+  it('emits no tiles when maxZoom is below the provider minzoom', () => {
+    const dl = makeDownloader(makeProvider({ minzoom: 5 }))
+    expect(dl.getTilesForBBox([0, 0, 1, 1], 3)).to.deep.equal([])
+  })
+})
+
+describe('chartDownloader: getSubTiles', () => {
+  const dl = makeDownloader(makeProvider())
+
+  it('returns the input tile when maxZoom equals its zoom', () => {
+    const tile: Tile = { x: 2, y: 3, z: 4 }
+    expect(dl.getSubTiles(tile, 4)).to.deep.equal([tile])
+  })
+
+  it('returns the expected child-tile count at each deeper zoom', () => {
+    // At zoom delta=d, a tile spawns 2^d × 2^d children. Plus the original.
+    const tile: Tile = { x: 0, y: 0, z: 2 }
+    const sub = dl.getSubTiles(tile, 4)
+    // z=2 (1) + z=3 (4) + z=4 (16) = 21
+    expect(sub.length).to.equal(1 + 4 + 16)
+  })
+
+  it('keeps children inside the parent quadrant', () => {
+    const parent: Tile = { x: 1, y: 1, z: 1 } // SE quadrant at z=1
+    const sub = dl.getSubTiles(parent, 3)
+    // z=3 children of (1,1,1) must have x,y in [4,7]
+    const atZ3 = sub.filter((t) => t.z === 3)
+    expect(atZ3.length).to.be.greaterThan(0)
+    for (const t of atZ3) {
+      expect(t.x).to.be.within(4, 7)
+      expect(t.y).to.be.within(4, 7)
+    }
+  })
+})
+
+describe('chartDownloader: getTilesForGeoJSON', () => {
+  const dl = makeDownloader(makeProvider())
+
+  it('returns tiles that intersect a simple polygon', () => {
+    const fc: FeatureCollection = {
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          properties: {},
+          geometry: {
+            type: 'Polygon',
+            coordinates: [
+              [
+                [0, 0],
+                [5, 0],
+                [5, 5],
+                [0, 5],
+                [0, 0]
+              ]
+            ]
+          }
+        }
+      ]
+    }
+    const tiles = dl.getTilesForGeoJSON(fc, 3, 3)
+    expect(tiles.length).to.be.greaterThan(0)
+    expect(tiles.every((t) => t.z === 3)).to.equal(true)
+  })
+
+  it('skips non-polygon features without failing', () => {
+    const fc: FeatureCollection = {
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          properties: {},
+          geometry: { type: 'Point', coordinates: [0, 0] }
+        }
+      ]
+    }
+    expect(dl.getTilesForGeoJSON(fc, 3, 3)).to.deep.equal([])
+  })
+})
+
+describe('chartDownloader: fetchTileFromRemote', () => {
+  it('returns null when the provider has no remoteUrl', async () => {
+    // Non-proxy providers still pass through this path from the seed job;
+    // a null return is the well-defined signal, not a throw.
+    const provider = makeProvider({ remoteUrl: undefined })
+    const result = await ChartDownloader.fetchTileFromRemote(provider, {
+      x: 0,
+      y: 0,
+      z: 1
+    })
+    expect(result).to.equal(null)
+  })
+})

--- a/test/charts-test.ts
+++ b/test/charts-test.ts
@@ -1,0 +1,61 @@
+/**
+ * Unit tests for charts.ts. findCharts is exercised against the real chart
+ * fixtures in test/charts; the goal here is to pin its contract (what it
+ * discovers, what it rejects) separately from the plugin-level integration
+ * scenarios in plugin-test.ts.
+ */
+
+import path from 'path'
+import { expect } from 'chai'
+import { findCharts } from '../src/charts'
+
+const CHARTS_DIR = path.resolve(__dirname, 'charts')
+
+describe('charts: findCharts', () => {
+  it('returns an identifier-keyed map of chart providers', async () => {
+    const result = await findCharts(CHARTS_DIR)
+    expect(result).to.be.an('object')
+    expect(Object.keys(result)).to.have.length.greaterThan(0)
+    for (const [id, chart] of Object.entries(result)) {
+      expect(chart.identifier).to.equal(id)
+    }
+  })
+
+  it('discovers the MBTiles fixture and tags its file format', async () => {
+    const result = await findCharts(CHARTS_DIR)
+    const mbtiles = result.test
+    expect(mbtiles, 'test.mbtiles fixture').to.exist
+    expect(mbtiles!._fileFormat).to.equal('mbtiles')
+    expect(mbtiles!.format).to.equal('png')
+  })
+
+  it('discovers directory-backed (TMS) charts with _flipY set', async () => {
+    const result = await findCharts(CHARTS_DIR)
+    const tms = result['tms-tiles']
+    expect(tms, 'tms-tiles fixture').to.exist
+    expect(tms!._fileFormat).to.equal('directory')
+    expect(tms!._flipY).to.equal(true)
+  })
+
+  it('discovers directory-backed (metadata.json) charts with _flipY cleared', async () => {
+    const result = await findCharts(CHARTS_DIR)
+    const unpacked = result['unpacked-tiles']
+    expect(unpacked, 'unpacked-tiles fixture').to.exist
+    expect(unpacked!._fileFormat).to.equal('directory')
+    expect(unpacked!._flipY).to.equal(false)
+  })
+
+  it('returns an empty map for a directory with no charts', async () => {
+    // The fixture tree contains subfolders of plain PNGs; without tilemap
+    // metadata they should not be treated as charts.
+    const result = await findCharts(path.join(CHARTS_DIR, 'tms-tiles', '4'))
+    expect(result).to.deep.equal({})
+  })
+
+  it('returns an empty map for a non-existent directory rather than throwing', async () => {
+    // A misconfigured chart path shouldn't take the plugin down; the caller
+    // logs and continues with the providers that did load.
+    const result = await findCharts(path.join(CHARTS_DIR, 'does-not-exist'))
+    expect(result).to.deep.equal({})
+  })
+})

--- a/test/plugin-test.ts
+++ b/test/plugin-test.ts
@@ -231,9 +231,11 @@ describe('GET /signalk/chart-tiles/:identifier/:z/:x/:y', () => {
   })
 
   it('returns 404 for missing tile', () => {
+    // Valid in-grid coordinates (2^5 = 32) but no file on disk: the TMS
+    // fixture only ships a small band in x/y.
     return plugin
       .start({})
-      .then(() => get(testServer, '/signalk/chart-tiles/tms-tiles/5/55/10'))
+      .then(() => get(testServer, '/signalk/chart-tiles/tms-tiles/5/10/10'))
       .catch((e) => e.response)
       .then((response) => {
         expect(response.status).to.equal(404)
@@ -247,6 +249,52 @@ describe('GET /signalk/chart-tiles/:identifier/:z/:x/:y', () => {
       .catch((e) => e.response)
       .then((response) => {
         expect(response.status).to.equal(404)
+      })
+  })
+
+  // Tile coordinate validation: out-of-range z / x / y. The Express regex only
+  // accepts digits, so validation covers the non-negative-but-bogus range
+  // (zoom above MAX_ZOOM, x or y at or above 2^z). z=0 is accepted because
+  // Leaflet's default minZoom is 0 — rejecting it would break legitimate
+  // framing requests from standard map clients.
+  it('accepts z=0 (Leaflet default minZoom) and 404s when the tile is absent', () => {
+    return plugin
+      .start({})
+      .then(() => get(testServer, '/signalk/chart-tiles/unpacked-tiles/0/0/0'))
+      .catch((e) => e.response)
+      .then((response) => {
+        expect(response.status).to.equal(404)
+      })
+  })
+
+  it('returns 400 for zoom above MAX_ZOOM (z=25)', () => {
+    return plugin
+      .start({})
+      .then(() => get(testServer, '/signalk/chart-tiles/unpacked-tiles/25/0/0'))
+      .catch((e) => e.response)
+      .then((response) => {
+        expect(response.status).to.equal(400)
+      })
+  })
+
+  it('returns 400 for x at the zoom boundary (x = 2^z)', () => {
+    // at z=4, valid x range is [0, 15]; x=16 is out of range
+    return plugin
+      .start({})
+      .then(() => get(testServer, '/signalk/chart-tiles/unpacked-tiles/4/16/0'))
+      .catch((e) => e.response)
+      .then((response) => {
+        expect(response.status).to.equal(400)
+      })
+  })
+
+  it('returns 400 for y at the zoom boundary (y = 2^z)', () => {
+    return plugin
+      .start({})
+      .then(() => get(testServer, '/signalk/chart-tiles/unpacked-tiles/4/0/16'))
+      .catch((e) => e.response)
+      .then((response) => {
+        expect(response.status).to.equal(400)
       })
   })
 })
@@ -400,6 +448,87 @@ describe('tile cache HTTP endpoints', () => {
       .execute(`http://localhost:${serverPort(testServer)}`)
       .post('/signalk/chart-tiles/cache/proxy-test')
       .send({ bbox: { minLon: 0, minLat: 0, maxLon: 1, maxLat: 1 } })
+      .catch((e) => e.response)
+    expect(res.status).to.equal(400)
+  })
+
+  // Zoom-validation checks run before bbox/tile inspection so the caller gets
+  // the most-specific rejection instead of a generic 500 from a downstream
+  // NaN-in-tile-math failure.
+  it('POST /cache/:identifier returns 400 for non-numeric maxZoom', async () => {
+    await plugin.start({ onlineChartProviders: [proxyProvider] })
+    const res = await chai.request
+      .execute(`http://localhost:${serverPort(testServer)}`)
+      .post('/signalk/chart-tiles/cache/proxy-test')
+      .send({
+        maxZoom: 'banana',
+        bbox: { minLon: 0, minLat: 0, maxLon: 1, maxLat: 1 }
+      })
+      .catch((e) => e.response)
+    expect(res.status).to.equal(400)
+  })
+
+  it('POST /cache/:identifier returns 400 for maxZoom above 24', async () => {
+    await plugin.start({ onlineChartProviders: [proxyProvider] })
+    const res = await chai.request
+      .execute(`http://localhost:${serverPort(testServer)}`)
+      .post('/signalk/chart-tiles/cache/proxy-test')
+      .send({
+        maxZoom: '25',
+        bbox: { minLon: 0, minLat: 0, maxLon: 1, maxLat: 1 }
+      })
+      .catch((e) => e.response)
+    expect(res.status).to.equal(400)
+  })
+
+  it('POST /cache/:identifier returns 400 for inverted bbox (minLat > maxLat)', async () => {
+    await plugin.start({ onlineChartProviders: [proxyProvider] })
+    const res = await chai.request
+      .execute(`http://localhost:${serverPort(testServer)}`)
+      .post('/signalk/chart-tiles/cache/proxy-test')
+      .send({
+        maxZoom: '5',
+        bbox: { minLon: 0, minLat: 10, maxLon: 1, maxLat: 5 }
+      })
+      .catch((e) => e.response)
+    expect(res.status).to.equal(400)
+  })
+
+  it('POST /cache/:identifier returns 400 for out-of-range latitude', async () => {
+    await plugin.start({ onlineChartProviders: [proxyProvider] })
+    const res = await chai.request
+      .execute(`http://localhost:${serverPort(testServer)}`)
+      .post('/signalk/chart-tiles/cache/proxy-test')
+      .send({
+        maxZoom: '5',
+        bbox: { minLon: 0, minLat: -91, maxLon: 1, maxLat: 90 }
+      })
+      .catch((e) => e.response)
+    expect(res.status).to.equal(400)
+  })
+
+  it('POST /cache/:identifier returns 400 for out-of-range longitude', async () => {
+    await plugin.start({ onlineChartProviders: [proxyProvider] })
+    const res = await chai.request
+      .execute(`http://localhost:${serverPort(testServer)}`)
+      .post('/signalk/chart-tiles/cache/proxy-test')
+      .send({
+        maxZoom: '5',
+        bbox: { minLon: -181, minLat: 0, maxLon: 181, maxLat: 10 }
+      })
+      .catch((e) => e.response)
+    expect(res.status).to.equal(400)
+  })
+
+  it('POST /cache/:identifier returns 400 for non-finite bbox value', async () => {
+    await plugin.start({ onlineChartProviders: [proxyProvider] })
+    const res = await chai.request
+      .execute(`http://localhost:${serverPort(testServer)}`)
+      .post('/signalk/chart-tiles/cache/proxy-test')
+      .send({
+        maxZoom: '5',
+        bbox: { minLon: 'nope', minLat: 0, maxLon: 1, maxLat: 1 }
+      })
       .catch((e) => e.response)
     expect(res.status).to.equal(400)
   })

--- a/test/projection-test.ts
+++ b/test/projection-test.ts
@@ -54,6 +54,26 @@ describe('projection: tileToBBox', () => {
     expect(bbox[0]).to.be.lessThan(bbox[2])
     expect(bbox[1]).to.be.lessThan(bbox[3])
   })
+
+  // Out-of-range x/y at a given zoom silently produced bbox coordinates
+  // outside the real-world range; downstream bbox math (turf) then operated
+  // on nonsense, turning a caller bug into a silent wrong-result. Fail fast.
+  it('throws for y at or above 2^z', () => {
+    // at z=2 the valid y range is [0, 3]; y=4 is outside the grid
+    expect(() => tileToBBox(0, 4, 2)).to.throw(RangeError)
+  })
+
+  it('throws for y below 0', () => {
+    expect(() => tileToBBox(0, -1, 2)).to.throw(RangeError)
+  })
+
+  it('throws for x at or above 2^z', () => {
+    expect(() => tileToBBox(4, 0, 2)).to.throw(RangeError)
+  })
+
+  it('throws for x below 0', () => {
+    expect(() => tileToBBox(-1, 0, 2)).to.throw(RangeError)
+  })
 })
 
 describe('projection: lonLatToMercator', () => {

--- a/test/publicClient-test.ts
+++ b/test/publicClient-test.ts
@@ -1,0 +1,126 @@
+/**
+ * Unit tests for the browser-side submitSeedJob helper in public/index.js.
+ * The function is extracted so the fetch + response-validation paths can be
+ * exercised in node with a mocked fetch, without spinning up jsdom. The DOM
+ * wiring itself is covered by manual QA on the Webapp panel.
+ */
+
+import { expect } from 'chai'
+
+type SeedJob = { id: number; [k: string]: unknown }
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { submitSeedJob } = require('../public/index.js') as {
+  submitSeedJob: (
+    chart: string,
+    body: unknown,
+    fetchImpl?: typeof fetch
+  ) => Promise<SeedJob>
+}
+
+// Minimal Response stand-in; the helper only reads `ok`, `status`, `json`
+// and `text`, so we don't need to satisfy the full DOM interface.
+type FakeResponse = {
+  ok: boolean
+  status?: number
+  json?: () => Promise<unknown>
+  text?: () => Promise<string>
+}
+
+const mockFetch =
+  (
+    responder: (url: string, init: RequestInit | undefined) => FakeResponse
+  ): typeof fetch =>
+  (url, init) =>
+    Promise.resolve(
+      responder(String(url), init)
+    ) as unknown as Promise<Response>
+
+describe('public client: submitSeedJob', () => {
+  it('sends a POST with JSON body and URL-encoded chart identifier', async () => {
+    // The chart identifier comes from the UI and may contain characters that
+    // require escaping (slashes, spaces); the helper should encode them so
+    // the server sees a single path segment.
+    let capturedUrl = ''
+    let capturedInit: RequestInit | undefined
+    const fetchImpl = mockFetch((url, init) => {
+      capturedUrl = url
+      capturedInit = init
+      return { ok: true, json: async () => ({ id: 1 }) }
+    })
+    await submitSeedJob('chart a/b', { maxZoom: '5' }, fetchImpl)
+    expect(capturedUrl).to.equal('/signalk/chart-tiles/cache/chart%20a%2Fb')
+    expect(capturedInit?.method).to.equal('POST')
+    expect(capturedInit?.headers).to.deep.equal({
+      'Content-Type': 'application/json'
+    })
+    expect(capturedInit?.body).to.equal(JSON.stringify({ maxZoom: '5' }))
+  })
+
+  it('returns the parsed job info on success', async () => {
+    const fetchImpl = mockFetch(() => ({
+      ok: true,
+      json: async () => ({ id: 42, totalTiles: 100, status: 0 })
+    }))
+    const job = await submitSeedJob('chart-1', {}, fetchImpl)
+    expect(job).to.include({ id: 42, totalTiles: 100 })
+  })
+
+  it('throws with the status and body when the server responds non-ok', async () => {
+    const fetchImpl = mockFetch(() => ({
+      ok: false,
+      status: 400,
+      text: async () => 'maxZoom out of range'
+    }))
+    try {
+      await submitSeedJob('chart-1', {}, fetchImpl)
+      expect.fail('expected submitSeedJob to throw')
+    } catch (err) {
+      expect((err as Error).message).to.include('400')
+      expect((err as Error).message).to.include('maxZoom out of range')
+    }
+  })
+
+  it('throws even when the error body cannot be read', async () => {
+    // Some proxies close the connection before the body is delivered. The
+    // helper should still surface the status code rather than masking the
+    // failure as a successful response.
+    const fetchImpl = mockFetch(() => ({
+      ok: false,
+      status: 502,
+      text: () => Promise.reject(new Error('stream closed'))
+    }))
+    try {
+      await submitSeedJob('chart-1', {}, fetchImpl)
+      expect.fail('expected submitSeedJob to throw')
+    } catch (err) {
+      expect((err as Error).message).to.include('502')
+    }
+  })
+
+  it('throws when the response body is missing a numeric id', async () => {
+    // Server contract change or misrouted request: refuse silently succeeding
+    // with no job to reference afterwards.
+    const fetchImpl = mockFetch(() => ({
+      ok: true,
+      json: async () => ({ status: 'weird' })
+    }))
+    try {
+      await submitSeedJob('chart-1', {}, fetchImpl)
+      expect.fail('expected submitSeedJob to throw')
+    } catch (err) {
+      expect((err as Error).message).to.include('numeric id')
+    }
+  })
+
+  it('propagates network errors from fetch', async () => {
+    const fetchImpl: typeof fetch = () =>
+      Promise.reject(new Error('ECONNREFUSED'))
+    try {
+      await submitSeedJob('chart-1', {}, fetchImpl)
+      expect.fail('expected submitSeedJob to throw')
+    } catch (err) {
+      expect((err as Error).message).to.equal('ECONNREFUSED')
+    }
+  })
+})

--- a/test/tileServer-test.ts
+++ b/test/tileServer-test.ts
@@ -1,0 +1,174 @@
+/**
+ * Unit tests for tileServer.ts. The HTTP-facing helpers
+ * (serveTileFromFilesystem / Mbtiles / CacheOrRemote) are exercised end-to-end
+ * in plugin-test.ts; here we focus on the pure validators and predicates so
+ * regressions surface with a clear assertion rather than via a 500 downstream.
+ */
+
+import { expect } from 'chai'
+import {
+  MAX_ZOOM,
+  MIN_TILE_Z,
+  MIN_ZOOM,
+  isAllowedTileFormat,
+  isMbtilesTileMissing,
+  validateBBox,
+  validateMaxZoom,
+  validateTileCoords
+} from '../src/tileServer'
+
+describe('tileServer: validateTileCoords', () => {
+  it('accepts a valid coordinate', () => {
+    expect(validateTileCoords(4, 5, 6)).to.equal(undefined)
+  })
+
+  it('accepts z=0 (Leaflet default minZoom)', () => {
+    // Rejecting z=0 broke standard map clients; the route-level bound sits
+    // below the provider-config bound on purpose.
+    expect(validateTileCoords(0, 0, 0)).to.equal(undefined)
+  })
+
+  it('rejects zoom below MIN_TILE_Z', () => {
+    expect(validateTileCoords(MIN_TILE_Z - 1, 0, 0)).to.be.a('string')
+  })
+
+  it('rejects zoom above MAX_ZOOM', () => {
+    expect(validateTileCoords(MAX_ZOOM + 1, 0, 0)).to.be.a('string')
+  })
+
+  it('rejects non-integer zoom', () => {
+    expect(validateTileCoords(3.5, 0, 0)).to.be.a('string')
+  })
+
+  it('rejects x at the zoom boundary (x = 2^z)', () => {
+    expect(validateTileCoords(4, 16, 0)).to.be.a('string')
+  })
+
+  it('rejects y at the zoom boundary (y = 2^z)', () => {
+    expect(validateTileCoords(4, 0, 16)).to.be.a('string')
+  })
+
+  it('rejects negative x', () => {
+    expect(validateTileCoords(4, -1, 0)).to.be.a('string')
+  })
+
+  it('rejects negative y', () => {
+    expect(validateTileCoords(4, 0, -1)).to.be.a('string')
+  })
+
+  it('rejects NaN coordinates', () => {
+    expect(validateTileCoords(NaN, 0, 0)).to.be.a('string')
+    expect(validateTileCoords(4, NaN, 0)).to.be.a('string')
+    expect(validateTileCoords(4, 0, NaN)).to.be.a('string')
+  })
+
+  it('accepts corner coordinates inside the grid', () => {
+    // at z=4 the valid range is 0..15 inclusive
+    expect(validateTileCoords(4, 0, 0)).to.equal(undefined)
+    expect(validateTileCoords(4, 15, 15)).to.equal(undefined)
+  })
+})
+
+describe('tileServer: validateMaxZoom', () => {
+  it('accepts a zoom inside the range', () => {
+    expect(validateMaxZoom(10)).to.equal(undefined)
+  })
+
+  it('accepts the inclusive bounds', () => {
+    expect(validateMaxZoom(MIN_ZOOM)).to.equal(undefined)
+    expect(validateMaxZoom(MAX_ZOOM)).to.equal(undefined)
+  })
+
+  it('rejects NaN', () => {
+    expect(validateMaxZoom(NaN)).to.be.a('string')
+  })
+
+  it('rejects a value below MIN_ZOOM', () => {
+    expect(validateMaxZoom(MIN_ZOOM - 1)).to.be.a('string')
+  })
+
+  it('rejects a value above MAX_ZOOM', () => {
+    expect(validateMaxZoom(MAX_ZOOM + 1)).to.be.a('string')
+  })
+})
+
+describe('tileServer: validateBBox', () => {
+  const valid = { minLon: 0, minLat: 0, maxLon: 1, maxLat: 1 }
+
+  it('accepts a valid bbox', () => {
+    expect(validateBBox(valid)).to.equal(undefined)
+  })
+
+  it('accepts a bbox that crosses the antimeridian (minLon > maxLon)', () => {
+    // real-world use case: a passage across the 180° line in the Pacific
+    expect(
+      validateBBox({ minLon: 170, minLat: -10, maxLon: -170, maxLat: 10 })
+    ).to.equal(undefined)
+  })
+
+  it('rejects a bbox with a non-number coordinate', () => {
+    expect(
+      validateBBox({ ...valid, minLon: 'nope' as unknown as number })
+    ).to.be.a('string')
+  })
+
+  it('rejects a bbox with an infinite coordinate', () => {
+    expect(validateBBox({ ...valid, maxLat: Infinity })).to.be.a('string')
+  })
+
+  it('rejects a bbox with longitude outside [-180, 180]', () => {
+    expect(validateBBox({ ...valid, minLon: -181 })).to.be.a('string')
+    expect(validateBBox({ ...valid, maxLon: 181 })).to.be.a('string')
+  })
+
+  it('rejects a bbox with latitude outside [-90, 90]', () => {
+    expect(validateBBox({ ...valid, minLat: -91 })).to.be.a('string')
+    expect(validateBBox({ ...valid, maxLat: 91 })).to.be.a('string')
+  })
+
+  it('rejects an inverted-latitude bbox (minLat >= maxLat)', () => {
+    expect(validateBBox({ ...valid, minLat: 5, maxLat: 5 })).to.be.a('string')
+    expect(validateBBox({ ...valid, minLat: 5, maxLat: 4 })).to.be.a('string')
+  })
+})
+
+describe('tileServer: isAllowedTileFormat', () => {
+  it('accepts known raster extensions regardless of case', () => {
+    expect(isAllowedTileFormat('png')).to.equal(true)
+    expect(isAllowedTileFormat('PNG')).to.equal(true)
+    expect(isAllowedTileFormat('jpg')).to.equal(true)
+    expect(isAllowedTileFormat('jpeg')).to.equal(true)
+  })
+
+  it('accepts the pbf vector extension', () => {
+    expect(isAllowedTileFormat('pbf')).to.equal(true)
+  })
+
+  it('rejects unknown extensions', () => {
+    expect(isAllowedTileFormat('gif')).to.equal(false)
+    expect(isAllowedTileFormat('webp')).to.equal(false)
+  })
+
+  it('rejects empty and undefined inputs', () => {
+    expect(isAllowedTileFormat('')).to.equal(false)
+    expect(isAllowedTileFormat(undefined)).to.equal(false)
+  })
+})
+
+describe('tileServer: isMbtilesTileMissing', () => {
+  it('matches the legacy message the library currently throws', () => {
+    expect(isMbtilesTileMissing(new Error('Tile does not exist'))).to.equal(
+      true
+    )
+  })
+
+  it('matches an ENOENT-coded error from a hypothetical newer release', () => {
+    const err = new Error('ENOENT: tile not found') as NodeJS.ErrnoException
+    err.code = 'ENOENT'
+    expect(isMbtilesTileMissing(err)).to.equal(true)
+  })
+
+  it('does not match unrelated errors', () => {
+    expect(isMbtilesTileMissing(new Error('SQLITE_CORRUPT'))).to.equal(false)
+  })
+})


### PR DESCRIPTION
## Summary

A punch list of maintainability, correctness and performance fixes after an audit of the plugin, with tests alongside.

### Correctness / security

- `GET /signalk/chart-tiles/:identifier/:z/:x/:y` now rejects out-of-range `z`, `x` and `y` with 400 before any filesystem or MBTiles lookup — previously a `z=999` request probed paths outside the zoom grid.
- `POST /signalk/chart-tiles/cache/:identifier` now validates `maxZoom` (finite, `[1, 24]`) and `bbox` (finite lon/lat in range, `minLat < maxLat`) before `createJob` runs, avoiding the generate-huge-tile-list-then-OOM failure mode.
- `tileToBBox` asserts `x` and `y` are inside the grid for the given `z`; silent NaN coordinates were reaching downstream bbox math.
- `seedCache` switched to `Promise.allSettled` with a post-settle status flip so a mid-job rejection can't corrupt counters while other tasks run.
- MBTiles 404 detection is centralised; a future library change (ENOENT code vs string message) now only touches one callsite.
- Duplicate `!id` check removed from `POST /cache/jobs/:id`; the second branch was unreachable.
- Client-side job-create response is shape-validated and surfaces errors to the user.

### Maintainability

- Tile-serving helpers (`serveTileFromFilesystem` / `Mbtiles` / `CacheOrRemote`), format allow-list, zoom bounds and validators extracted from `src/index.ts` into new `src/tileServer.ts` (index.ts: 874 -> 790 lines, tile-serving concerns now cohesive).
- `_mbtilesHandle: any` replaced by a concrete `MBTilesHandle` interface; `MBTilesMetadata` added for parser input.
- Production modules now each have their own unit test file (`tileServer-test.ts`, `chartDownloader-test.ts`, `charts-test.ts`, existing `projection-test.ts`) alongside the `plugin-test.ts` integration suite.
- Stray `console.log` on the unknown-file-format branch replaced with `app.debug`.
- Dead `!provider.remoteUrl` branch cleaned up and documented for the non-proxy-seeding path.

### Performance

- Removed the redundant `fs.stat` + `fs.access` probe on every tile request; `res.sendFile` already stats and error-maps, now via its error callback.
- Fetch abort timer cleared immediately after the response head is in, instead of in `finally` — large body reads can no longer race the abort.
- Disk-space probing moved from every-1000-tiles to a 30-second cadence.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx prettier --check .` clean
- [x] `npm test` — 101 passing (was 46), including new boundary / bbox / antimeridian / mbtiles-404 cases
- [ ] Install the built plugin into a Signal K server; verify tile serving, seeding and the Webapp job panel still work as before