### PR TITLE
fix: open mbtiles read-only and guard EventEmitter errors

### DIFF
--- a/src/charts.ts
+++ b/src/charts.ts
@@ -152,13 +152,21 @@ function openMbtilesFile(
       reject(mbtilesLoadError ?? new Error('MBTiles module not loaded'))
       return
     }
-    new MBTiles(file, (err, mbtiles) => {
+    // mode=ro: open read-only. Without this the library defaults to rwc,
+    // which needs the containing directory writable so SQLite can create its
+    // rollback journal. That breaks read-only mounts (Docker volumes, NFS,
+    // SMB) with SQLITE_CANTOPEN even though the plugin never writes.
+    const instance = new MBTiles(`${file}?mode=ro`, (err, mbtiles) => {
       if (err) return reject(err)
       mbtiles.getInfo((infoErr, metadata) => {
         if (infoErr) return reject(infoErr)
         resolve({ mbtiles, metadata })
       })
     })
+    // MBTiles extends EventEmitter; an unhandled 'error' event crashes the
+    // node process. Reject is idempotent after the promise settles, so this
+    // also swallows any stray runtime error on this handle.
+    instance.on('error', reject)
   })
     .then(({ mbtiles, metadata }) => {
       if (

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,9 @@ export interface MBTilesHandle {
     callback: (err: Error | null, metadata: MBTilesMetadata) => void
   ) => void
   close: (callback: (err: Error | null) => void) => void
+  // MBTiles inherits from EventEmitter. We only need 'error' so an unhandled
+  // event doesn't bring down the node process.
+  on: (event: 'error', listener: (err: Error) => void) => MBTilesHandle
 }
 
 // MBTiles metadata rows relevant to the plugin. `bounds` is commonly a


### PR DESCRIPTION
## Summary

- Open MBTiles files with `?mode=ro`. SQLite's default `rwc` mode needs the containing directory writable so it can create a rollback journal. Charts served off read-only mounts (Docker volumes, NFS, SMB, immutable overlays) fail to open with `SQLITE_CANTOPEN` even though the plugin never writes to mbtiles.
- Attach an `'error'` listener on the MBTiles instance. The library extends `EventEmitter`, and an unhandled `'error'` event crashes the node process. The listener rejects the open promise (idempotent after settling), so it also covers later runtime errors on the same handle.

## Why

Reproduced in the field as:

```
Error loading chart /share/charts/USA/US-WA-Columbia-Willamette-Snake-Rivers.Bing.Z10-Z18.2023-12.mbtiles SQLITE_CANTOPEN: unable to open database file
```

on a read-only `/share` mount. The file was readable, but SQLite couldn't create its journal in the directory.

## Test plan

- [ ] `npm test` passes, including `ignores invalid files without dropping good charts`
- [ ] Verified load succeeds against an mbtiles on a read-only bind mount
- [ ] Verified tiles still serve correctly (read path unchanged)