### PR TITLE
fix(logo): fill rounded-corner cutouts with white

### DIFF
--- a/public/logo.svg
+++ b/public/logo.svg
@@ -13,6 +13,8 @@
     </clipPath>
   </defs>
 
+  <rect x="0" y="0" width="128" height="128" fill="#fff"/>
+
   <g clip-path="url(#card)">
     <rect width="128" height="128" fill="url(#sea)"/>
 


### PR DESCRIPTION
## Summary

Closes #85. The webapp list renders the icon on a colored background, so the transparent corners around the rounded card bled the page color through and read as a dark border.

Fill the SVG canvas with white behind the clipped rounded card so the four corners stay white regardless of what sits behind them in the admin UI. Otherwise the logo is unchanged from what shipped in v3.6.0.

## Test plan

- [x] Verified the container-served logo has white corners in the Signal K admin UI Webapps list.
- [ ] Spot-check next to App Dock.