### PR TITLE
fix(reload): keep last-good chart set when a reload errors mid-scan

### DIFF
--- a/src/charts.ts
+++ b/src/charts.ts
@@ -67,13 +67,18 @@ async function loadMBTiles() {
 const MAX_SCAN_DEPTH = 8
 const PARSE_CONCURRENCY = 12
 
+// onScanError is invoked when a scan step hits something that could leave
+// the result set incomplete (readdir failure, non-ENOENT fs.stat, MBTiles
+// open crash). The caller uses it to distinguish "legitimately zero charts"
+// from "transient failure that should fall back to the last-good set".
 export async function findCharts(
-  chartBaseDir: string
+  chartBaseDir: string,
+  onScanError?: () => void
 ): Promise<{ [identifier: string]: ChartProvider }> {
   await loadMBTiles()
   const charts: ChartProvider[] = []
   const limit = pLimit(PARSE_CONCURRENCY)
-  await scanDir(chartBaseDir, charts, 0, limit)
+  await scanDir(chartBaseDir, charts, 0, limit, onScanError)
   const result: { [identifier: string]: ChartProvider } = {}
   for (const chart of charts) {
     result[chart.identifier] = chart
@@ -85,13 +90,20 @@ async function scanDir(
   dir: string,
   out: ChartProvider[],
   depth: number,
-  limit: ReturnType<typeof pLimit>
+  limit: ReturnType<typeof pLimit>,
+  onScanError?: () => void
 ): Promise<void> {
   if (depth > MAX_SCAN_DEPTH) return
   let entries: Dirent[]
   try {
     entries = await fs.readdir(dir, { withFileTypes: true })
   } catch (err) {
+    // ENOENT on a configured-but-missing chart path is not a transient
+    // failure — it's a user misconfiguration and we shouldn't preserve a
+    // stale set because of it. Any other code (EACCES, EBUSY, EIO, EMFILE,
+    // ...) is treated as transient.
+    const code = (err as NodeJS.ErrnoException).code
+    if (code !== 'ENOENT' && onScanError) onScanError()
     console.error(
       `Error reading charts directory ${dir}:${(err as Error).message}`
     )
@@ -115,7 +127,7 @@ async function scanDir(
       tasks.push(
         (async () => {
           const chart = await limit(() =>
-            openMbtilesFile(entryPath, entry.name)
+            openMbtilesFile(entryPath, entry.name, onScanError)
           )
           if (chart) out.push(chart as ChartProvider)
         })()
@@ -124,12 +136,12 @@ async function scanDir(
       tasks.push(
         (async () => {
           const chart = await limit(() =>
-            directoryToMapInfo(entryPath, entry.name)
+            directoryToMapInfo(entryPath, entry.name, onScanError)
           )
           if (chart) {
             out.push(chart as ChartProvider)
           } else {
-            await scanDir(entryPath, out, depth + 1, limit)
+            await scanDir(entryPath, out, depth + 1, limit, onScanError)
           }
         })()
       )
@@ -145,7 +157,8 @@ interface LoadedMbtiles {
 
 function openMbtilesFile(
   file: string,
-  filename: string
+  filename: string,
+  onScanError?: () => void
 ): Promise<ChartProvider | null> {
   return new Promise<LoadedMbtiles>((resolve, reject) => {
     if (!MBTiles) {
@@ -209,6 +222,7 @@ function openMbtilesFile(
     })
     .catch((e: Error) => {
       console.error(`Error loading chart ${file}`, e.message)
+      if (onScanError) onScanError()
       return null
     })
 }
@@ -233,18 +247,44 @@ function parseVectorLayers(layers: Array<{ id: string }>) {
   return layers.map((l) => l.id)
 }
 
-function directoryToMapInfo(file: string, identifier: string) {
+function directoryToMapInfo(
+  file: string,
+  identifier: string,
+  onScanError?: () => void
+) {
   async function loadInfo() {
     const tilemapResource = path.join(file, 'tilemapresource.xml')
     const metadataJson = path.join(file, 'metadata.json')
+    // ENOENT means "file not present", which is normal — this dir just isn't
+    // a chart and the caller will recurse into it. Any other fs.stat error
+    // (EACCES, EBUSY, EIO, EMFILE, ...) is transient or configuration-level
+    // and should flag the scan so the caller can preserve the last-good set.
     try {
       await fs.stat(tilemapResource)
       return parseTilemapResource(tilemapResource)
-    } catch {
+    } catch (e1) {
+      const code1 = (e1 as NodeJS.ErrnoException).code
+      if (code1 && code1 !== 'ENOENT') {
+        console.warn(
+          `Signal K Charts: fs.stat ${tilemapResource} failed: ${
+            (e1 as Error).message
+          }`
+        )
+        if (onScanError) onScanError()
+      }
       try {
         await fs.stat(metadataJson)
         return parseMetadataJson(metadataJson)
-      } catch {
+      } catch (e2) {
+        const code2 = (e2 as NodeJS.ErrnoException).code
+        if (code2 && code2 !== 'ENOENT') {
+          console.warn(
+            `Signal K Charts: fs.stat ${metadataJson} failed: ${
+              (e2 as Error).message
+            }`
+          )
+          if (onScanError) onScanError()
+        }
         return null
       }
     }
@@ -275,6 +315,7 @@ function directoryToMapInfo(file: string, identifier: string) {
     })
     .catch((e) => {
       console.error(`Error getting charts from ${file}`, e.message)
+      if (onScanError) onScanError()
       return null
     })
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -244,6 +244,14 @@ const createPlugin = (app: ChartProviderApp): Plugin => {
       return doStartup(settings) // return required for tests
     },
     stop: () => {
+      // Surface stop() calls so an unexpected Signal K-initiated restart
+      // (config reload, server shutdown, error cascade) is visible in logs
+      // instead of silently emptying chartProviders.
+      console.log(
+        `Signal K Charts: stop() called (${
+          Object.keys(chartProviders).length
+        } provider(s) will be released)`
+      )
       stopWatchers()
       // Cancel any running seeding jobs so a disabled plugin doesn't keep
       // pulling tiles from remote providers in the background.
@@ -332,9 +340,20 @@ const createPlugin = (app: ChartProviderApp): Plugin => {
     // own per-file concurrency internally, so kicking off multiple roots at
     // once just overlaps their directory reads.
     let results: ({ [key: string]: ChartProvider } | undefined)[]
+    // onScanError fires when findCharts hits a non-trivial error (readdir
+    // failure, non-ENOENT fs.stat, MBTiles open crash) — i.e. something that
+    // could leave chartProviders incomplete. A reload that produces zero
+    // charts with errorsDuringScan=true is treated as transient and the
+    // last-good set is kept; without errors, zero is trusted as legitimate
+    // (user deleted all chart files).
+    let errorsDuringScan = false
     try {
       results = await Promise.all(
-        activeChartPaths.map((chartPath) => findCharts(chartPath))
+        activeChartPaths.map((chartPath) =>
+          findCharts(chartPath, () => {
+            errorsDuringScan = true
+          })
+        )
       )
     } catch (e) {
       // Keep the last-good chartProviders instead of wiping everything - a
@@ -371,6 +390,31 @@ const createPlugin = (app: ChartProviderApp): Plugin => {
         Object.keys(newCharts).length
       } charts from ${activeChartPaths.join(', ')}.`
     )
+
+    // Defensive: if a reload turns up zero local charts AND something went
+    // wrong during the scan (errorsDuringScan) AND we previously held charts,
+    // treat the empty result as transient and keep the last-good set instead
+    // of quietly 404-ing every tile request until the next successful reload.
+    // Zero charts WITHOUT errors is trusted (user legitimately removed all
+    // charts).
+    const previousLocalCount = Object.keys(chartProviders).filter(
+      (id) => !activeOnlineProviders[id]
+    ).length
+    if (
+      Object.keys(newCharts).length === 0 &&
+      previousLocalCount > 0 &&
+      errorsDuringScan
+    ) {
+      console.warn(
+        `Signal K Charts: reload produced 0 charts from [${activeChartPaths.join(
+          ', '
+        )}] after errors during scan; keeping last-good set of ${previousLocalCount} chart(s).`
+      )
+      app.setPluginStatus(
+        composeStatus(perPath, Object.keys(activeOnlineProviders).length)
+      )
+      return
+    }
 
     reconcileMbtilesHandles(chartProviders)
     // Shallow assign is enough: newCharts and activeOnlineProviders both

--- a/test/charts-test.ts
+++ b/test/charts-test.ts
@@ -58,4 +58,31 @@ describe('charts: findCharts', () => {
     const result = await findCharts(path.join(CHARTS_DIR, 'does-not-exist'))
     expect(result).to.deep.equal({})
   })
+
+  it('does not invoke onScanError for a non-existent directory (ENOENT)', async () => {
+    // ENOENT is the "user misconfiguration" path, not a transient failure —
+    // the caller should trust the empty result rather than preserve a stale
+    // last-good set because of it.
+    let errorFired = false
+    await findCharts(path.join(CHARTS_DIR, 'does-not-exist'), () => {
+      errorFired = true
+    })
+    expect(errorFired).to.equal(false)
+  })
+
+  it('invokes onScanError when readdir fails with a non-ENOENT code', async () => {
+    // Pointing findCharts at a file (not a directory) yields ENOTDIR from
+    // readdir, which represents the class of transient / unexpected failures
+    // the callback is meant to flag. The caller uses this signal to keep
+    // the last-good chart set instead of wiping providers.
+    let errorFired = false
+    const result = await findCharts(
+      path.join(CHARTS_DIR, 'test.mbtiles'),
+      () => {
+        errorFired = true
+      }
+    )
+    expect(errorFired).to.equal(true)
+    expect(result).to.deep.equal({})
+  })
 })


### PR DESCRIPTION
## Summary

Users have reported chart tiles silently 404-ing after the plugin has been running for a while — no errors in the log, `DEBUG=charts` shows nothing, and a server restart is the only remedy.

The most plausible trigger: a watcher-triggered reload scans the chart directory, hits a transient non-ENOENT failure inside \`directoryToMapInfo\` or \`scanDir\` (EACCES, EBUSY, EIO, EMFILE, ENOTDIR, …), and swallows it silently. \`newCharts\` comes back empty, \`loadChartProviders\` unconditionally replaces \`chartProviders\` with \`{}\`, and every subsequent tile request returns 404 because the identifier no longer exists in the map.

This PR does two things:

- **Thread an \`onScanError\` callback through \`findCharts\`** so the caller can distinguish a legitimately-empty scan (\"user deleted all charts\") from a failed scan. ENOENT on the chart path is explicitly **not** treated as a scan error, so the existing misconfigured-path behavior is preserved.
- **Guard \`loadChartProviders\`**: when the new result is empty, something errored during the scan, and the previous set was non-empty, keep the last-good set and \`console.warn\` so the condition is visible without \`DEBUG=charts\`.

Also surfaces \`stop()\` calls via \`console.log\` so an unexpected Signal K-initiated plugin restart is visible in the logs.

## Test plan

- [x] \`npx tsc --noEmit\` clean.
- [x] \`npm test\` — 126 passing. Added two unit tests in \`test/charts-test.ts\`: ENOENT does not fire the callback; readdir on a file (ENOTDIR) does.
- [x] Existing \"drops a chart that has been deleted\" test still passes (legitimate-empty case is preserved).
- [ ] Ship alongside #85 / #88 and monitor the warn log the next time a user hits the 404 state — the message will confirm whether this was the path.