### PR TITLE
Sea/land filter, hardened (alternative to #87)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,16 +9,19 @@
       "version": "3.6.2",
       "license": "Apache-2.0",
       "dependencies": {
+        "@geo-maps/earth-seas-10m": "^0.6.0",
         "@signalk/mbtiles": "0.1.1",
         "@signalk/server-api": "^2.0.0",
         "@turf/bbox": "^7.2.0",
         "@turf/boolean-intersects": "^7.2.0",
+        "@turf/boolean-point-in-polygon": "^7.3.5",
         "@turf/helpers": "^7.2.0",
         "check-disk-space": "^3.4.0",
         "fast-xml-parser": "^5.7.1",
         "geojson-antimeridian-cut": "^0.1.0",
         "lodash": "^4.17.11",
-        "p-limit": "^7"
+        "p-limit": "^7",
+        "rbush": "^4.0.1"
       },
       "devDependencies": {
         "@stryker-mutator/core": "^9.6.1",
@@ -28,6 +31,7 @@
         "@types/lodash": "^4.14.191",
         "@types/mocha": "^10.0.10",
         "@types/node": "^25.6.0",
+        "@types/rbush": "^4.0.0",
         "c8": "^11.0.0",
         "chai": "6.2.2",
         "chai-http": "^5.1.2",
@@ -1022,6 +1026,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/@geo-maps/earth-seas-10m": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@geo-maps/earth-seas-10m/-/earth-seas-10m-0.6.0.tgz",
+      "integrity": "sha512-SwRe8GJDCfLxeE+gXYavjvmb3DVgkuiCuKFVp8jgIUYU9vz1wj+71J2GGAPmyg1lLT22ByIPCnTfFVWVlXLmuw==",
+      "license": "MIT"
+    },
     "node_modules/@inquirer/ansi": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.5.tgz",
@@ -1936,6 +1946,13 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/rbush": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/rbush/-/rbush-4.0.0.tgz",
+      "integrity": "sha512-+N+2H39P8X+Hy1I5mC6awlTX54k3FhiUmvt7HWzGJZvF+syUAAxP/stwppS8JE84YHqFgRMv6fCy31202CMFxQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -4538,6 +4555,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/quickselect": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
+      "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
+      "license": "ISC"
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -4572,6 +4595,15 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/rbush": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-4.0.1.tgz",
+      "integrity": "sha512-IP0UpfeWQujYC8Jg162rMNc01Rf0gWMMAb2Uxus/Q0qOFw4lCcq6ZnQEZwUoJqWyUGJ9th7JjwI4yIWo+uvoAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "quickselect": "^3.0.0"
       }
     },
     "node_modules/readdirp": {

--- a/package.json
+++ b/package.json
@@ -37,16 +37,19 @@
     "appIcon": "./logo.svg"
   },
   "dependencies": {
+    "@geo-maps/earth-seas-10m": "^0.6.0",
     "@signalk/mbtiles": "0.1.1",
     "@signalk/server-api": "^2.0.0",
     "@turf/bbox": "^7.2.0",
     "@turf/boolean-intersects": "^7.2.0",
+    "@turf/boolean-point-in-polygon": "^7.3.5",
     "@turf/helpers": "^7.2.0",
     "check-disk-space": "^3.4.0",
     "fast-xml-parser": "^5.7.1",
     "geojson-antimeridian-cut": "^0.1.0",
     "lodash": "^4.17.11",
-    "p-limit": "^7"
+    "p-limit": "^7",
+    "rbush": "^4.0.1"
   },
   "repository": {
     "type": "git",
@@ -60,6 +63,7 @@
     "@types/lodash": "^4.14.191",
     "@types/mocha": "^10.0.10",
     "@types/node": "^25.6.0",
+    "@types/rbush": "^4.0.0",
     "c8": "^11.0.0",
     "chai": "6.2.2",
     "chai-http": "^5.1.2",

--- a/src/@types/geo-maps_earth-seas-10m.d.ts
+++ b/src/@types/geo-maps_earth-seas-10m.d.ts
@@ -1,0 +1,8 @@
+declare module '@geo-maps/earth-seas-10m' {
+  import type { GeometryCollection, MultiPolygon } from 'geojson'
+  // The package ships a single MultiPolygon-only GeometryCollection covering
+  // the world's oceans and seas at 10m resolution. Calling the factory parses
+  // and returns it; callers cache the result so the ~36 MB JSON is read once.
+  function getMap(): GeometryCollection<MultiPolygon>
+  export default getMap
+}

--- a/src/biomeFilter.ts
+++ b/src/biomeFilter.ts
@@ -1,0 +1,97 @@
+/**
+ * Biome (sea/land) filter for chart download jobs.
+ *
+ * Decides whether a given tile should be downloaded under a given biome
+ * filter, by sampling the tile bbox at a small set of points and asking a
+ * BiomeOracle whether each point is over sea or land. Kept separate from
+ * seaIndex.ts so the "where does the biome come from" question (data-source,
+ * caching, R-tree) stays independent from the "how do I filter tiles" one.
+ */
+
+import type { Tile } from './chartDownloader'
+import type { BiomeFilter } from './types'
+import type { BiomeOracle } from './seaIndex'
+import { tileToBBox } from './projection'
+
+// Sample the tile bbox at a 3x3 grid (corners + edge midpoints + centre).
+// Catches inland water bodies and offshore islands roughly half a tile
+// across or larger; smaller features can still slip through the gaps.
+const sampleTilePoints = (
+  minLon: number,
+  minLat: number,
+  maxLon: number,
+  maxLat: number
+): readonly [number, number][] => {
+  const midLon = (minLon + maxLon) / 2
+  const midLat = (minLat + maxLat) / 2
+  return [
+    [minLon, minLat],
+    [midLon, minLat],
+    [maxLon, minLat],
+    [minLon, midLat],
+    [midLon, midLat],
+    [maxLon, midLat],
+    [minLon, maxLat],
+    [midLon, maxLat],
+    [maxLon, maxLat]
+  ]
+}
+
+// Decide whether a single tile matches the requested biome. Short-circuits
+// at the first decisive sample (one sea sample is enough to clear 'sea';
+// one land sample is enough to clear 'land'). The geo-maps dataset omits
+// inland lakes, so an inland-lake tile reports as land for this filter.
+export const tileMatchesBiome = (
+  tile: Tile,
+  filter: BiomeFilter,
+  oracle: BiomeOracle
+): boolean => {
+  const [minLon, minLat, maxLon, maxLat] = tileToBBox(tile.x, tile.y, tile.z)
+  for (const [lon, lat] of sampleTilePoints(minLon, minLat, maxLon, maxLat)) {
+    const sampleIsSea = oracle.isPointInSea(lon, lat)
+    if (filter === 'sea' && sampleIsSea) return true
+    if (filter === 'land' && !sampleIsSea) return true
+  }
+  return false
+}
+
+export interface FilterTilesOptions {
+  // Polled between tiles so a long filter pass doesn't outlive a cancelled
+  // job. Returning true breaks out of the loop and returns whatever has
+  // been classified so far.
+  isCancelled?: () => boolean
+  // Wall-clock budget in milliseconds before we yield to the event loop
+  // via setImmediate. Defaults to 50 ms — long enough for the per-tile
+  // overhead to be amortised, short enough that unrelated request handling
+  // is not starved during a multi-thousand-tile filter pass.
+  yieldMs?: number
+}
+
+const DEFAULT_YIELD_MS = 50
+
+// Drop tiles that don't match the requested biome. Pure (no shared state)
+// so the same helper drives the seed-job pre-pass, ad-hoc tooling, and
+// every test suite. The yield-on-budget keeps the Node event loop
+// responsive when a CPU-bound classification pass runs over thousands of
+// tiles; setImmediate runs after pending I/O callbacks but before any new
+// timers, which matches what we want here.
+export const filterTilesByBiome = async (
+  tiles: readonly Tile[],
+  filter: BiomeFilter,
+  oracle: BiomeOracle,
+  options: FilterTilesOptions = {}
+): Promise<Tile[]> => {
+  const yieldMs = options.yieldMs ?? DEFAULT_YIELD_MS
+  const isCancelled = options.isCancelled
+  const out: Tile[] = []
+  let lastYield = Date.now()
+  for (const tile of tiles) {
+    if (isCancelled?.()) break
+    if (Date.now() - lastYield >= yieldMs) {
+      await new Promise<void>((resolve) => setImmediate(resolve))
+      lastYield = Date.now()
+    }
+    if (tileMatchesBiome(tile, filter, oracle)) out.push(tile)
+  }
+  return out
+}

--- a/src/chartDownloader.ts
+++ b/src/chartDownloader.ts
@@ -18,6 +18,8 @@ import { ResourcesApi } from '@signalk/server-api'
 import { ChartProvider } from './types'
 import { lonLatToMercator, lonLatToTile, tileToBBox } from './projection'
 import { MIN_ZOOM } from './tileServer'
+import { BiomeOracle, defaultBiomeOracle } from './seaIndex'
+import { filterTilesByBiome } from './biomeFilter'
 
 export interface Tile {
   x: number
@@ -40,9 +42,15 @@ export class ChartSeedingManager {
     maxZoom: number,
     regionGUID: string | undefined = undefined,
     bbox: BBox | undefined = undefined,
-    tile: Tile | undefined = undefined
+    tile: Tile | undefined = undefined,
+    oracle: BiomeOracle = defaultBiomeOracle
   ): Promise<ChartDownloader> {
-    const downloader = new ChartDownloader(resourcesApi, chartsPath, provider)
+    const downloader = new ChartDownloader(
+      resourcesApi,
+      chartsPath,
+      provider,
+      oracle
+    )
     // Init must complete before the job is usable; callers get back a job that
     // knows its tile set and totalTiles. Without awaiting, a follow-up "start"
     // action would race the init reads of this.tiles.
@@ -75,6 +83,10 @@ export class ChartDownloader {
   private downloadedTiles = 0
   private failedTiles = 0
   private cachedTiles = 0
+  // Tiles dropped by the biome (sea/land) filter at seed start. Tracked
+  // separately from failedTiles so the progress fraction can include
+  // intentionally-skipped tiles and reach 1.0 cleanly when the rest finish.
+  private skippedByFilterTiles = 0
 
   private concurrentDownloadsLimit = 20
   private areaDescription = ''
@@ -86,7 +98,8 @@ export class ChartDownloader {
   constructor(
     private resourcesApi: ResourcesApi,
     private chartsPath: string,
-    private provider: ChartProvider
+    private provider: ChartProvider,
+    private biomeOracle: BiomeOracle = defaultBiomeOracle
   ) {}
 
   get ID(): number {
@@ -153,10 +166,26 @@ export class ChartDownloader {
 
     this.cancelRequested = false
     this.status = Status.Running
-    this.tilesToDownload = await this.filterCachedTiles(this.tiles)
     this.downloadedTiles = 0
     this.failedTiles = 0
-    this.cachedTiles = this.totalTiles - this.tilesToDownload.length
+    this.skippedByFilterTiles = 0
+    // Biome filter runs before cache and IO so totalTiles accounting stays
+    // honest, the live tile-serving path is never gated, and locality wins
+    // (skipping all-land children of an all-land parent) become possible.
+    // Throws here propagate up — failing the whole job is preferable to
+    // silently ignoring a misconfigured filter and downloading every tile.
+    const tilesAfterFilter =
+      this.provider.biomeFilter === undefined
+        ? this.tiles
+        : await filterTilesByBiome(
+            this.tiles,
+            this.provider.biomeFilter,
+            this.biomeOracle,
+            { isCancelled: () => this.cancelRequested }
+          )
+    this.skippedByFilterTiles = this.tiles.length - tilesAfterFilter.length
+    this.tilesToDownload = await this.filterCachedTiles(tilesAfterFilter)
+    this.cachedTiles = tilesAfterFilter.length - this.tilesToDownload.length
     const limit = pLimit(this.concurrentDownloadsLimit) // concurrent download limit
     let lastDiskCheck = 0
 
@@ -280,9 +309,13 @@ export class ChartDownloader {
       downloadedTiles: this.downloadedTiles,
       cachedTiles: this.cachedTiles,
       failedTiles: this.failedTiles,
+      skippedByFilterTiles: this.skippedByFilterTiles,
       progress:
         this.totalTiles > 0
-          ? (this.downloadedTiles + this.cachedTiles + this.failedTiles) /
+          ? (this.downloadedTiles +
+              this.cachedTiles +
+              this.failedTiles +
+              this.skippedByFilterTiles) /
             this.totalTiles
           : 0,
       status: this.status
@@ -331,6 +364,7 @@ export class ChartDownloader {
     if (!provider.remoteUrl) {
       return null
     }
+
     let url = provider.remoteUrl
       .replace('{z}', tile.z.toString())
       // To be able to handle NOAA WMTS caching as a tilemap source with -2 offset

--- a/src/index.ts
+++ b/src/index.ts
@@ -197,6 +197,14 @@ const createPlugin = (app: ChartProviderApp): Plugin => {
                 'Create a proxy to serve remote tiles and cache fetched tiles from the remote server, to serve them locally on subsequent requests. Use webapp to configure seeding jobs to prefetch tiles to local cache.',
               default: false
             },
+            biomeFilter: {
+              type: 'string',
+              title: 'Biome filter',
+              description:
+                'Restrict which tiles are downloaded during seeding. "Sea" downloads only tiles that contain any sea, "Land" downloads only tiles that contain any land. Leave unset to download every tile.',
+              enum: ['', 'sea', 'land'],
+              default: ''
+            },
             headers: {
               type: 'array',
               title: 'Headers',
@@ -825,6 +833,13 @@ const convertOnlineProviderConfig = (provider: OnlineChartProvider) => {
       layers: provider.layers ? provider.layers : null
     },
     proxy: provider.proxy ? provider.proxy : false,
+    // The schema's empty-string sentinel ('' === no filter) collapses here
+    // to undefined so the downstream filter only runs when the user has
+    // actually opted in.
+    biomeFilter:
+      provider.biomeFilter === 'sea' || provider.biomeFilter === 'land'
+        ? provider.biomeFilter
+        : undefined,
     remoteUrl: provider.proxy ? provider.url : null,
     headers: parseHeaders(provider.headers)
   }

--- a/src/seaIndex.ts
+++ b/src/seaIndex.ts
@@ -1,0 +1,122 @@
+/**
+ * Sea/land classification used by the chart-downloader's biome filter.
+ *
+ * The geo-maps package ships a single ~36 MB GeometryCollection containing
+ * one MultiPolygon that covers every connected ocean and major sea at 10 m
+ * resolution. Loading and indexing it on first use rather than at module
+ * init keeps the cost off callers that never seed (the v1 charts route or
+ * unit tests that stub the oracle).
+ */
+
+import RBush from 'rbush'
+import booleanPointInPolygon from '@turf/boolean-point-in-polygon'
+import { polygon } from '@turf/helpers'
+import getSeasMap from '@geo-maps/earth-seas-10m'
+import type { Feature, Polygon } from 'geojson'
+
+export interface BiomeOracle {
+  isPointInSea(lon: number, lat: number): boolean
+}
+
+type SeaIndexEntry = {
+  minX: number
+  minY: number
+  maxX: number
+  maxY: number
+  feature: Feature<Polygon>
+}
+
+// Build the rbush of polygon-bbox entries from the geo-maps dataset. The
+// full polygon (outer ring + holes) is stored on each entry: the dataset's
+// largest polygon spans every connected ocean and uses tens of thousands
+// of holes to punch out the continents and islands it encloses, so a
+// point-in-polygon query against the outer ring alone would classify
+// every continent as sea.
+// The loader is overridable so tests can drive the malformed-dataset error
+// path without monkey-patching require.cache. Production callers never
+// override it.
+type SeasLoader = () => ReturnType<typeof getSeasMap>
+let seasLoader: SeasLoader = getSeasMap
+export const _setSeasLoaderForTesting = (loader: SeasLoader): void => {
+  seasLoader = loader
+  cached = null
+}
+export const _restoreSeasLoaderForTesting = (): void => {
+  seasLoader = getSeasMap
+  cached = null
+}
+
+const buildSeaIndex = (): RBush<SeaIndexEntry> => {
+  const collection = seasLoader()
+  const geometry = collection.geometries[0]
+  if (!geometry || geometry.type !== 'MultiPolygon') {
+    throw new Error(
+      `@geo-maps/earth-seas-10m returned ${
+        geometry?.type ?? 'undefined'
+      } geometry; expected MultiPolygon`
+    )
+  }
+  const tree = new RBush<SeaIndexEntry>()
+  const items = geometry.coordinates.map((coords): SeaIndexEntry => {
+    let minX = Infinity
+    let minY = Infinity
+    let maxX = -Infinity
+    let maxY = -Infinity
+    // Bbox is taken from the outer ring (index 0). Holes are by GeoJSON
+    // construction strictly inside the outer ring, so they cannot extend it.
+    const outer = coords[0]!
+    for (const [x, y] of outer) {
+      if (x! < minX) minX = x!
+      if (y! < minY) minY = y!
+      if (x! > maxX) maxX = x!
+      if (y! > maxY) maxY = y!
+    }
+    return { minX, minY, maxX, maxY, feature: polygon(coords) }
+  })
+  tree.load(items)
+  return tree
+}
+
+// Three states: not yet built, built successfully, or built and failed.
+// The failure is memoized so a malformed dataset does not re-parse 36 MB
+// of JSON on every retry — once it has failed, every subsequent call
+// re-throws the cached error.
+type CacheEntry =
+  | { kind: 'ok'; tree: RBush<SeaIndexEntry> }
+  | { kind: 'err'; error: Error }
+let cached: CacheEntry | null = null
+
+const ensureIndex = (): RBush<SeaIndexEntry> => {
+  if (cached === null) {
+    try {
+      cached = { kind: 'ok', tree: buildSeaIndex() }
+    } catch (e) {
+      cached = {
+        kind: 'err',
+        error: e instanceof Error ? e : new Error(String(e))
+      }
+    }
+  }
+  if (cached.kind === 'err') throw cached.error
+  return cached.tree
+}
+
+// Default biome oracle backed by the geo-maps dataset. Lazy: the first call
+// builds the index. After that, queries are O(log n) bbox lookup followed
+// by booleanPointInPolygon on the (small) candidate set.
+export const defaultBiomeOracle: BiomeOracle = {
+  isPointInSea(lon: number, lat: number): boolean {
+    const candidates = ensureIndex().search({
+      minX: lon,
+      minY: lat,
+      maxX: lon,
+      maxY: lat
+    })
+    for (const candidate of candidates) {
+      if (booleanPointInPolygon([lon, lat], candidate.feature)) {
+        return true
+      }
+    }
+    return false
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,9 +71,14 @@ export interface ChartProvider {
   style?: string
   layers?: string[]
   proxy?: boolean
+  biomeFilter?: BiomeFilter
   remoteUrl?: string
   headers?: { [key: string]: string }
 }
+
+// 'sea' downloads tiles that contain any sea; 'land' downloads tiles that
+// contain any land; absent means no filter and every tile is downloaded.
+export type BiomeFilter = 'sea' | 'land'
 
 export interface OnlineChartProvider {
   name: string
@@ -84,6 +89,7 @@ export interface OnlineChartProvider {
   format: 'png' | 'jpg'
   url: string
   proxy: boolean
+  biomeFilter?: BiomeFilter
   headers?: string[]
   style: string
   layers: string[]

--- a/test/chartDownloader-test.ts
+++ b/test/chartDownloader-test.ts
@@ -9,6 +9,13 @@ import { expect } from 'chai'
 import type { FeatureCollection } from 'geojson'
 import { ChartDownloader, Tile } from '../src/chartDownloader'
 import { ChartProvider } from '../src/types'
+import {
+  defaultBiomeOracle,
+  BiomeOracle,
+  _setSeasLoaderForTesting,
+  _restoreSeasLoaderForTesting
+} from '../src/seaIndex'
+import { tileMatchesBiome, filterTilesByBiome } from '../src/biomeFilter'
 
 // Minimal provider scaffold; only the fields the tile-math methods read must
 // be populated (minzoom, name, format). Using an as-cast rather than a full
@@ -167,5 +174,332 @@ describe('chartDownloader: fetchTileFromRemote', () => {
       z: 1
     })
     expect(result).to.equal(null)
+  })
+})
+
+describe('chartDownloader: tileMatchesBiome', () => {
+  // The filter samples tile bboxes at a 3x3 grid. A fake oracle lets each
+  // case pin exactly which samples come back as sea vs land, so the test
+  // exercises the filter logic without depending on the geo-maps dataset.
+  const fakeOracle = (verdicts: boolean[]): BiomeOracle => {
+    let i = 0
+    return {
+      isPointInSea: () => {
+        const v = verdicts[i % verdicts.length]
+        i += 1
+        return v ?? false
+      }
+    }
+  }
+  const ALL_SEA = Array(9).fill(true)
+  const ALL_LAND = Array(9).fill(false)
+  // 4 sea + 5 land samples — coastline tile that crosses both biomes.
+  const COASTAL = [true, true, false, true, false, false, true, false, false]
+  const ANY_TILE: Tile = { x: 100, y: 100, z: 8 }
+
+  it("'sea' filter accepts a tile whose samples are all sea", () => {
+    expect(tileMatchesBiome(ANY_TILE, 'sea', fakeOracle(ALL_SEA))).to.equal(
+      true
+    )
+  })
+
+  it("'sea' filter rejects a tile whose samples are all land", () => {
+    expect(tileMatchesBiome(ANY_TILE, 'sea', fakeOracle(ALL_LAND))).to.equal(
+      false
+    )
+  })
+
+  it("'land' filter accepts a tile whose samples are all land", () => {
+    expect(tileMatchesBiome(ANY_TILE, 'land', fakeOracle(ALL_LAND))).to.equal(
+      true
+    )
+  })
+
+  it("'land' filter rejects a tile whose samples are all sea", () => {
+    expect(tileMatchesBiome(ANY_TILE, 'land', fakeOracle(ALL_SEA))).to.equal(
+      false
+    )
+  })
+
+  it('coastal tile (mixed samples) is accepted by both filters', () => {
+    expect(tileMatchesBiome(ANY_TILE, 'sea', fakeOracle(COASTAL))).to.equal(
+      true
+    )
+    expect(tileMatchesBiome(ANY_TILE, 'land', fakeOracle(COASTAL))).to.equal(
+      true
+    )
+  })
+
+  it('short-circuits at the first decisive sample', () => {
+    let calls = 0
+    const oracle: BiomeOracle = {
+      isPointInSea: () => {
+        calls += 1
+        return true
+      }
+    }
+    tileMatchesBiome(ANY_TILE, 'sea', oracle)
+    expect(calls).to.equal(1)
+  })
+})
+
+describe('biomeFilter: filterTilesByBiome', () => {
+  const seaOracle: BiomeOracle = { isPointInSea: () => true }
+  const landOracle: BiomeOracle = { isPointInSea: () => false }
+  const tiles: Tile[] = [
+    { x: 0, y: 0, z: 4 },
+    { x: 1, y: 0, z: 4 },
+    { x: 2, y: 0, z: 4 }
+  ]
+
+  it("keeps every tile when the oracle agrees with the 'sea' filter", async () => {
+    const out = await filterTilesByBiome(tiles, 'sea', seaOracle)
+    expect(out).to.deep.equal(tiles)
+  })
+
+  it("drops every tile when the oracle disagrees with the 'sea' filter", async () => {
+    const out = await filterTilesByBiome(tiles, 'sea', landOracle)
+    expect(out).to.deep.equal([])
+  })
+
+  it('stops early when the cancellation callback returns true', async () => {
+    let classified = 0
+    const oracle: BiomeOracle = {
+      isPointInSea: () => {
+        classified += 1
+        return true
+      }
+    }
+    const out = await filterTilesByBiome(tiles, 'sea', oracle, {
+      isCancelled: () => classified >= 1 // one tile classified, then bail
+    })
+    expect(out.length).to.equal(1)
+  })
+})
+
+describe('chartDownloader: filterTilesByBiome integration', () => {
+  // Drives the real seedCache → filterTilesByBiome path through a
+  // ChartDownloader instance with a fake oracle, so the per-tile counter
+  // updates and progress accounting are exercised end-to-end without
+  // touching the network or the 36 MB geo-maps dataset.
+  type FetchStub = {
+    fn: typeof fetch
+    calls: number
+  }
+  const installFetchStub = (): FetchStub => {
+    const stub: FetchStub = {
+      calls: 0,
+      fn: undefined as unknown as typeof fetch
+    }
+    stub.fn = (async () => {
+      stub.calls += 1
+      return new Response(new Uint8Array([1, 2, 3, 4]), { status: 200 })
+    }) as unknown as typeof fetch
+    globalThis.fetch = stub.fn
+    return stub
+  }
+  let originalFetch: typeof fetch
+  before(() => {
+    originalFetch = globalThis.fetch
+  })
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  const seaOnlyOracle: BiomeOracle = { isPointInSea: () => true }
+  const landOnlyOracle: BiomeOracle = { isPointInSea: () => false }
+
+  const seedTwoTiles = async (
+    biomeFilter: 'sea' | 'land',
+    oracle: BiomeOracle
+  ) => {
+    const provider = makeProvider({
+      remoteUrl: 'https://example.invalid/{z}/{x}/{y}.png',
+      biomeFilter
+    })
+    const downloader = new ChartDownloader(
+      {} as never,
+      '/tmp/sk-charts-test-' + Math.random().toString(36).slice(2),
+      provider,
+      oracle
+    )
+    await downloader.initializeJobFromBBox([0, 0, 1, 1], 4)
+    const stub = installFetchStub()
+    await downloader.seedCache()
+    return { info: downloader.info(), fetchCalls: stub.calls }
+  }
+
+  it('skipped tiles increment skippedByFilterTiles, not failedTiles', async () => {
+    const { info } = await seedTwoTiles('sea', landOnlyOracle)
+    expect(info.failedTiles).to.equal(0)
+    expect(info.skippedByFilterTiles).to.be.greaterThan(0)
+    expect(info.skippedByFilterTiles).to.equal(info.totalTiles)
+  })
+
+  it('progress reaches 1.0 when every tile is filtered out', async () => {
+    const { info } = await seedTwoTiles('sea', landOnlyOracle)
+    expect(info.progress).to.equal(1)
+  })
+
+  it('matching tiles still hit the network', async () => {
+    const { info, fetchCalls } = await seedTwoTiles('sea', seaOnlyOracle)
+    expect(info.skippedByFilterTiles).to.equal(0)
+    expect(fetchCalls).to.be.greaterThan(0)
+  })
+
+  it('skips the filter pass entirely when no biomeFilter is set', async () => {
+    let oracleCalls = 0
+    const trackingOracle: BiomeOracle = {
+      isPointInSea: () => {
+        oracleCalls += 1
+        return true
+      }
+    }
+    const provider = makeProvider({
+      remoteUrl: 'https://example.invalid/{z}/{x}/{y}.png'
+      // no biomeFilter — pre-pass should not run, oracle never consulted
+    })
+    const downloader = new ChartDownloader(
+      {} as never,
+      '/tmp/sk-charts-test-' + Math.random().toString(36).slice(2),
+      provider,
+      trackingOracle
+    )
+    await downloader.initializeJobFromBBox([0, 0, 1, 1], 4)
+    installFetchStub()
+    await downloader.seedCache()
+    expect(oracleCalls).to.equal(0)
+    expect(downloader.info().skippedByFilterTiles).to.equal(0)
+  })
+
+  it('yields the event loop when classification exceeds 50 ms', async function () {
+    // Force the filter loop past the FILTER_YIELD_MS threshold by busy-
+    // waiting inside the oracle on the first call. The second tile then
+    // triggers the setImmediate path. Verifies the filter does not block
+    // the loop on long classification runs.
+    this.timeout(5_000)
+    let firstCall = true
+    const slowOracle: BiomeOracle = {
+      isPointInSea: () => {
+        if (firstCall) {
+          firstCall = false
+          const start = Date.now()
+          while (Date.now() - start < 60) {
+            // busy-wait > 50 ms
+          }
+        }
+        return true
+      }
+    }
+    let setImmediateCalls = 0
+    const originalSetImmediate = globalThis.setImmediate
+    globalThis.setImmediate = ((fn: (...args: unknown[]) => void) => {
+      setImmediateCalls += 1
+      return originalSetImmediate(fn)
+    }) as unknown as typeof setImmediate
+    try {
+      await seedTwoTiles('sea', slowOracle)
+    } finally {
+      globalThis.setImmediate = originalSetImmediate
+    }
+    expect(setImmediateCalls).to.be.greaterThan(0)
+  })
+})
+
+describe('chartDownloader: fetchTileFromRemote (post-filter-relayer)', () => {
+  // The biome filter has been moved out of fetchTileFromRemote into the
+  // job-init pre-pass. fetchTileFromRemote no longer consults onlySea/onlyLand
+  // so the live tile-serving path (which routes through fetchTileFromRemote)
+  // is unaffected by a provider's biomeFilter setting.
+  let originalFetch: typeof fetch
+  before(() => {
+    originalFetch = globalThis.fetch
+  })
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  it('downloads a tile regardless of biomeFilter', async () => {
+    let called = 0
+    globalThis.fetch = (async () => {
+      called += 1
+      return new Response(new Uint8Array([1]), { status: 200 })
+    }) as unknown as typeof fetch
+    const provider = makeProvider({
+      remoteUrl: 'https://example.invalid/{z}/{x}/{y}.png',
+      // Even though biomeFilter is set, fetchTileFromRemote ignores it.
+      // Filtering happens earlier, in seedCache.
+      biomeFilter: 'sea'
+    })
+    const result = await ChartDownloader.fetchTileFromRemote(provider, {
+      x: 0,
+      y: 0,
+      z: 1
+    })
+    expect(result).to.be.instanceOf(Buffer)
+    expect(called).to.equal(1)
+  })
+})
+
+describe('seaIndex: defaultBiomeOracle init failure handling', () => {
+  // Restore the real loader after each test so subsequent describes can
+  // exercise the dataset.
+  afterEach(() => {
+    _restoreSeasLoaderForTesting()
+  })
+
+  it('throws a descriptive error when the dataset is the wrong shape', () => {
+    _setSeasLoaderForTesting(
+      () =>
+        ({
+          type: 'GeometryCollection',
+          // Wrong inner type: dataset must contain a single MultiPolygon.
+          geometries: [{ type: 'Point', coordinates: [0, 0] }]
+        }) as never
+    )
+    expect(() => defaultBiomeOracle.isPointInSea(0, 0)).to.throw(
+      /returned Point geometry; expected MultiPolygon/
+    )
+  })
+
+  it('memoizes the failure so repeated calls do not re-parse', () => {
+    let loaderCalls = 0
+    _setSeasLoaderForTesting(() => {
+      loaderCalls += 1
+      return {
+        type: 'GeometryCollection',
+        geometries: []
+      } as never
+    })
+    expect(() => defaultBiomeOracle.isPointInSea(0, 0)).to.throw()
+    expect(() => defaultBiomeOracle.isPointInSea(1, 1)).to.throw()
+    expect(() => defaultBiomeOracle.isPointInSea(2, 2)).to.throw()
+    // Loader should have run at most once even though three queries failed.
+    expect(loaderCalls).to.equal(1)
+  })
+})
+
+describe('seaIndex: defaultBiomeOracle (real dataset)', function () {
+  // The real geo-maps dataset takes ~400 ms to parse + index on first use,
+  // so warm it up in a before() hook with extra timeout instead of paying
+  // it in the timing budget of any single test.
+  this.timeout(10_000)
+  before(() => {
+    defaultBiomeOracle.isPointInSea(0, 0)
+  })
+
+  it('classifies the mid-South-Atlantic as sea', () => {
+    expect(defaultBiomeOracle.isPointInSea(-30, -30)).to.equal(true)
+  })
+
+  it('classifies the central Sahara as land', () => {
+    expect(defaultBiomeOracle.isPointInSea(15, 22)).to.equal(false)
+  })
+
+  it('classifies inner Madagascar as land (polygon-hole regression guard)', () => {
+    // The geo-maps "all oceans" polygon punches Madagascar out as an inner
+    // ring, so a PIP test that ignored holes would mark Madagascar as sea.
+    // The 47°E 19°S sample sits well inland.
+    expect(defaultBiomeOracle.isPointInSea(47, -19)).to.equal(false)
   })
 })

--- a/test/plugin-test.ts
+++ b/test/plugin-test.ts
@@ -129,6 +129,8 @@ describe('GET /resources/charts', () => {
       })
       .then(() => get(testServer, '/signalk/v1/api/resources/charts'))
       .then((result) => {
+        // biomeFilter is undefined when no filter is configured; JSON
+        // serialization drops it, so the response body omits the field.
         expect(result.body['test-name']).to.deep.equal({
           bounds: [-180, -90, 180, 90],
           format: 'jpg',
@@ -145,6 +147,72 @@ describe('GET /resources/charts', () => {
           type: 'tilelayer',
           chartLayers: null
         })
+      })
+  })
+
+  it("online provider with biomeFilter='sea' carries the value through to the resolved config", () => {
+    return plugin
+      .start({
+        chartPaths: ['charts'],
+        onlineChartProviders: [
+          {
+            name: 'Sea Only',
+            minzoom: 2,
+            maxzoom: 15,
+            format: 'jpg',
+            url: 'https://example.com',
+            biomeFilter: 'sea'
+          }
+        ]
+      })
+      .then(() => get(testServer, '/signalk/v1/api/resources/charts'))
+      .then((result) => {
+        expect(result.body['sea-only'].biomeFilter).to.equal('sea')
+      })
+  })
+
+  it("online provider with biomeFilter='land' carries the value through to the resolved config", () => {
+    return plugin
+      .start({
+        chartPaths: ['charts'],
+        onlineChartProviders: [
+          {
+            name: 'Land Only',
+            minzoom: 2,
+            maxzoom: 15,
+            format: 'jpg',
+            url: 'https://example.com',
+            biomeFilter: 'land'
+          }
+        ]
+      })
+      .then(() => get(testServer, '/signalk/v1/api/resources/charts'))
+      .then((result) => {
+        expect(result.body['land-only'].biomeFilter).to.equal('land')
+      })
+  })
+
+  it("biomeFilter='' (empty-string sentinel) collapses to undefined", () => {
+    // The schema uses an empty string to mean "no filter" because some UI
+    // generators don't render a clearable enum. The plugin must treat that
+    // as equivalent to leaving the field off.
+    return plugin
+      .start({
+        chartPaths: ['charts'],
+        onlineChartProviders: [
+          {
+            name: 'No Filter',
+            minzoom: 2,
+            maxzoom: 15,
+            format: 'jpg',
+            url: 'https://example.com',
+            biomeFilter: '' as unknown as 'sea'
+          }
+        ]
+      })
+      .then(() => get(testServer, '/signalk/v1/api/resources/charts'))
+      .then((result) => {
+        expect(result.body['no-filter'].biomeFilter).to.equal(undefined)
       })
   })
 


### PR DESCRIPTION
Picks up the sea/land download filter from #87 (preserved with original commit SHAs and Okan credited via author in the commit), then addresses the review findings on top.

## Summary

- **Filter relayer**: moved from `fetchTileFromRemote` to a pre-pass at the top of `seedCache`. The live HTTP tile-serving path no longer 502s for biome-mismatched tiles, and a new `skippedByFilterTiles` counter feeds `info()` so progress reaches 1.0 cleanly when the filter culls tiles. Cancellation is honoured between tiles, and the filter loop yields via `setImmediate` every 50 ms so a 10 k-tile inland seed doesn't starve the rest of the SignalK process during the (CPU-bound) classification pass.
- **Schema**: replaced `onlySea` + `onlyLand` booleans with a single `biomeFilter: 'sea' | 'land'` enum. The XOR fallback, the both-flags warning, the dedicated XOR test, and the gotcha paragraph in schema text all dissolve.
- **Dependency tree**: dropped `is-sea` and the `@turf/* v6` tree it pulled in; depend on `@geo-maps/earth-seas-10m` directly with `rbush` + `@turf/boolean-point-in-polygon` (turf v7 throughout). Lockfile shrinks by ~5 470 lines.
- **Correctness**: builds an R-tree of the 582 polygon parts and tests against the **full** polygon (outer ring + 60 k holes) so continents enclosed in the all-oceans polygon are correctly classified as land. `_setSeasLoaderForTesting` memoizes the failure path so a malformed dataset throws once instead of re-parsing 36 MB JSON per tile.
- **Modularization**: split into [`src/seaIndex.ts`](https://github.com/msallin/charts-plugin/blob/pr-87-cleanup/src/seaIndex.ts) (where does the biome come from?) and [`src/biomeFilter.ts`](https://github.com/msallin/charts-plugin/blob/pr-87-cleanup/src/biomeFilter.ts) (how do I filter tiles by biome?). The downloader only consumes the high-level `filterTilesByBiome(tiles, filter, oracle, options)` API.

## Tests

- 149 passing (was 41 in the original PR).
- New unit tests for `tileMatchesBiome`, `filterTilesByBiome` (with cancellation), and the `BiomeOracle` failure-memoization path, all driven by injected fake oracles.
- Integration tests against the real geo-maps dataset for mid-Atlantic (sea), central Sahara (land), and **inner Madagascar** — a polygon-hole regression guard that distinguishes "outer-ring only" from "outer + holes" PIP. The four-corner test in #87 happened to pass either way.
- Plugin-level tests pin `biomeFilter='sea'`, `'land'`, and the empty-string sentinel collapse to `undefined`.

## Test plan

- [x] `npm test` — all 149 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npm run coverage` — `biomeFilter.ts` 100% lines / 93% branches; `seaIndex.ts` 99% lines / 92% branches
- [x] manually tested by @okankurtulus 

## TODO

- [ ] Discuss with @tkurki (added as reviewer, pinged on Discord) -> only concern is the +32MB dependency (on disk; loaded on demand)