### PR TITLE
chore: drop Node 20/22, support Node 24/26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [22.x, 24.x]
+        node-version: [24.x, 26.x]
 
     steps:
       - name: Checkout

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@types/express": "^5.0.6",
         "@types/lodash": "^4.14.191",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.6.0",
+        "@types/node": "^25.9.2",
         "c8": "^11.0.0",
         "chai": "6.2.2",
         "chai-http": "^5.1.2",
@@ -37,6 +37,9 @@
         "rimraf": "^6.1.3",
         "tsx": "^4.20.3",
         "typescript": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=24"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "prepublishOnly": "npm run build"
   },
   "license": "Apache-2.0",
+  "engines": {
+    "node": ">=24"
+  },
   "keywords": [
     "signalk",
     "signalk-node-server-plugin",
@@ -62,7 +65,7 @@
     "@types/express": "^5.0.6",
     "@types/lodash": "^4.14.191",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.6.0",
+    "@types/node": "^25.9.2",
     "c8": "^11.0.0",
     "chai": "6.2.2",
     "chai-http": "^5.1.2",


### PR DESCRIPTION
> **Hold for Venus OS.** This is going to land as soon as Venus OS supports Node v24 (see [Discord context](https://discord.com/channels/1170433917761892493/1512189657666949441/1512439811477078048)).

Drop Node 20 and 22, support Node 24 and 26.

- `engines.node`: `>=20.10` → `>=24` (drops the Cerbo special-case; the Cerbo runtime will catch up, and `>=24` unlocks Node 24+ APIs).
- CI matrix: `[20.x, 22.x, 24.x]` → `[24.x, 26.x]`. Coverage stays on Node 24 (LTS); 26.x is the regression-catcher.
- `@types/node`: bumped to `^25.9.2` (latest published; DefinitelyTyped hasn't released `@types/node@26` yet — Node 26 only landed a few days ago. Bump again once DT publishes).